### PR TITLE
(BOLT-315) Install bolt to /opt/puppetlabs/bin

### DIFF
--- a/configs/components/bolt.rb
+++ b/configs/components/bolt.rb
@@ -5,10 +5,12 @@ component "bolt" do |pkg, settings, platform|
   pkg.requires "puppet-agent"
 
   pkg.build do
-    ["/opt/puppetlabs/puppet/bin/gem build bolt.gemspec"]
+    ["#{settings[:bindir]}/gem build bolt.gemspec"]
   end
 
   pkg.install do
     ["#{settings[:gem_install]} bolt-*.gem"]
   end
+
+  pkg.link "#{settings[:bindir]}/bolt", "#{settings[:link_bindir]}/bolt"
 end

--- a/configs/projects/bolt.rb
+++ b/configs/projects/bolt.rb
@@ -10,6 +10,7 @@ project "bolt" do |proj|
   proj.identifier "com.puppetlabs"
 
   proj.setting(:bindir, "/opt/puppetlabs/puppet/bin")
+  proj.setting(:link_bindir, "/opt/puppetlabs/bin")
   proj.setting(:gem_path, "/opt/puppetlabs/puppet/lib/ruby/gems/2.4.0")
   proj.setting(:gem_install, "#{proj.bindir}/gem install --no-rdoc --no-ri --bindir=#{proj.bindir} --local --force ")
   proj.setting(:artifactory_url, "https://artifactory.delivery.puppetlabs.net/artifactory")
@@ -45,5 +46,6 @@ project "bolt" do |proj|
   proj.component 'bolt'
 
   proj.directory proj.bindir
+  proj.directory proj.link_bindir
   proj.directory proj.gem_path
 end


### PR DESCRIPTION
This makes it available on PATH in a default puppet-agent install.