### PR TITLE
(BOLT-519) Bump version of orchestrator_client gem

### DIFF
--- a/configs/components/rubygem-orchestrator_client.rb
+++ b/configs/components/rubygem-orchestrator_client.rb
@@ -1,7 +1,7 @@
 component "rubygem-orchestrator_client" do |pkg, settings, platform|
   gemname = pkg.get_name.gsub('rubygem-', '')
-  pkg.version "0.2.4"
-  pkg.md5sum "69238f7de8c34d54650c8bc987a2a59c"
+  pkg.version "0.2.6"
+  pkg.md5sum "1b5bd2be87beaa7ee9ac57d6046941d9"
   pkg.url "https://rubygems.org/downloads/#{gemname}-#{pkg.get_version}.gem"
   pkg.mirror "#{settings[:buildsources_url]}/#{gemname}-#{pkg.get_version}.gem"
 


### PR DESCRIPTION
BOLT-519 required updates to orchestrator_client-ruby code. Specifically ability to set User-Agent headers.