### PR TITLE
(BOLT-617) Include net-ssh-krb gem for kerberos support for SSH

### DIFF
--- a/configs/components/rubygem-net-ssh-krb.rb
+++ b/configs/components/rubygem-net-ssh-krb.rb
@@ -1,0 +1,12 @@
+component "rubygem-net-ssh-krb" do |pkg, settings, platform|
+  gemname = pkg.get_name.gsub('rubygem-', '')
+  pkg.version "0.4.0"
+  pkg.md5sum "a19209530717d3b1254aebb2ab230635"
+  pkg.url "https://rubygems.org/downloads/#{gemname}-#{pkg.get_version}.gem"
+  pkg.mirror "#{settings[:buildsources_url]}/#{gemname}-#{pkg.get_version}.gem"
+
+  pkg.install do
+    "#{settings[:gem_install]} #{gemname}-#{pkg.get_version}.gem"
+  end
+end
+

--- a/configs/projects/puppet-bolt.rb
+++ b/configs/projects/puppet-bolt.rb
@@ -51,6 +51,7 @@ project "puppet-bolt" do |proj|
   proj.component 'rubygem-unicode-display_width'
   proj.component 'rubygem-winrm'
   proj.component 'rubygem-gssapi'
+  proj.component 'rubygem-net-ssh-krb'
   proj.component 'rubygem-httpclient'
   proj.component 'rubygem-rubyntlm'
   proj.component 'rubygem-logging'


### PR DESCRIPTION
For gem installations, we don't include a dependency on net-ssh-krb and
treat it as optional. Since the gem is small and easy to install, it
makes sense to bundle it in the package so anyone using the package can
benefit from kerberos support out of the box.