### PR TITLE
(maint) Update packaging dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,6 @@ end
 gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 0.7")
 gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 0.1")
 gem 'vanagon', *location_for(ENV['VANAGON_LOCATION'] || '~> 0.15')
-gem 'packaging', *location_for(ENV['PACKAGING_LOCATION'] || '~> 0.99')
+gem 'packaging', *location_for(ENV['PACKAGING_LOCATION'] || '~> 0.99.7')
 gem 'json'
 gem 'rake'


### PR DESCRIPTION
Packaging dependency must be >= 0.99.7 for bionic support.