### PR TITLE
(BOLT-686) Update orchestrator_client to 0.3.0 for TLS fix

### DIFF
--- a/configs/components/rubygem-orchestrator_client.rb
+++ b/configs/components/rubygem-orchestrator_client.rb
@@ -1,7 +1,7 @@
 component "rubygem-orchestrator_client" do |pkg, settings, platform|
   gemname = pkg.get_name.gsub('rubygem-', '')
-  pkg.version "0.2.6"
-  pkg.md5sum "1b5bd2be87beaa7ee9ac57d6046941d9"
+  pkg.version "0.3.0"
+  pkg.md5sum "e81d18cdf501e5995a1b963809cf37a3"
   pkg.url "https://rubygems.org/downloads/#{gemname}-#{pkg.get_version}.gem"
   pkg.mirror "#{settings[:buildsources_url]}/#{gemname}-#{pkg.get_version}.gem"
 


### PR DESCRIPTION
Updates orchestrator_client to 0.3.0, which always uses TLS v1.2. This
makes it use the latest TLS release that Orchestrator supports.