### PR TITLE
(BOLT-689) Add support for building bolt-server on Ubuntu 18.04

### DIFF
--- a/configs/platforms/ubuntu-18.04-amd64.rb
+++ b/configs/platforms/ubuntu-18.04-amd64.rb
@@ -1,12 +1,14 @@
+peversion = IO.read('peversion').strip
 platform "ubuntu-18.04-amd64" do |plat|
   plat.servicedir "/lib/systemd/system"
   plat.defaultdir "/etc/default"
   plat.servicetype "systemd"
   plat.codename "bionic"
 
+  plat.provision_with "curl https://enterprise.delivery.puppetlabs.net/pluto.pub.gpg | apt-key add - "
+  plat.apt_repo "http://enterprise.delivery.puppetlabs.net/#{peversion}/repos/#{plat.get_name}/#{plat.get_name}.repo"
   plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-#{plat.get_codename}.deb"
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper rsync fakeroot"
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vmpooler_template "ubuntu-1804-x86_64"
-  plat.output_dir File.join("deb", plat.get_codename, "PC1")
 end


### PR DESCRIPTION
Also installs a GPG key so Ubuntu 18.04 will accept the repository.

Remove the output_dir to be consistent with other Ubuntu platform
configs.