### PR TITLE
(maint) Use published runtime settings rather than git repo

### DIFF
--- a/configs/components/bolt-runtime.rb
+++ b/configs/components/bolt-runtime.rb
@@ -1,15 +1,15 @@
 component 'bolt-runtime' do |pkg, settings, platform|
   # The JSON name intentionally differs from the component, because automation to update
   # the puppet-runtime ref relies on the puppet-runtime name.
-  runtime_details = JSON.parse(File.read('configs/components/puppet-runtime.json'))
-  runtime_tag = runtime_details['ref'][/refs\/tags\/(.*)/, 1]
-  raise "Unable to determine a tag for bolt-runtime (given #{runtime_details['ref']})" unless runtime_tag
-  pkg.version runtime_tag
+  unless settings[:puppet_runtime_version] && settings[:puppet_runtime_location] && settings[:puppet_runtime_basename]
+    raise "Expected to find :puppet_runtime_version, :puppet_runtime_location, and :puppet_runtime_basename settings; Please set these in your project file before including puppet-runtime as a component."
+  end
 
-  tarball_name = "bolt-runtime-#{pkg.get_version}.#{platform.name}.tar.gz"
+  pkg.version settings[:puppet_runtime_version]
 
-  pkg.sha1sum "http://builds.puppetlabs.lan/puppet-runtime/#{pkg.get_version}/artifacts/#{tarball_name}.sha1"
-  pkg.url "http://builds.puppetlabs.lan/puppet-runtime/#{pkg.get_version}/artifacts/#{tarball_name}"
+  tarball_name = "#{settings[:puppet_runtime_basename]}.tar.gz"
+  pkg.url File.join(settings[:puppet_runtime_location], tarball_name)
+  pkg.sha1sum File.join(settings[:puppet_runtime_location], "#{tarball_name}.sha1")
 
   pkg.install_only true
 

--- a/configs/components/puppet-runtime.json
+++ b/configs/components/puppet-runtime.json
@@ -1,1 +1,1 @@
-{"url":"git://github.com/puppetlabs/puppet-runtime.git","ref":"refs/tags/201808080"}
+{"location":"http://builds.delivery.puppetlabs.net/puppet-runtime/201808080/artifacts/","version":"201808080"}

--- a/configs/projects/puppet-bolt.rb
+++ b/configs/projects/puppet-bolt.rb
@@ -2,10 +2,15 @@ project "puppet-bolt" do |proj|
   # bolt inherits most build settings from puppetlabs/puppet-runtime:
   # - Modifications to global settings like flags and target directories should be made in puppet-runtime.
   # - Settings included in this file should apply only to local components in this repository.
-  runtime_details = JSON.parse(File.read(File.join(File.dirname(__FILE__), '..', 'components/puppet-runtime.json')))
-  runtime_tag = runtime_details['ref'][/refs\/tags\/(.*)/, 1]
-  raise "Unable to determine a tag for bolt-runtime (given #{runtime_details['ref']})" unless runtime_tag
-  proj.inherit_settings 'bolt-runtime', runtime_details['url'], runtime_tag
+  runtime_details = JSON.parse(File.read('configs/components/puppet-runtime.json'))
+
+  settings[:puppet_runtime_version] = runtime_details['version']
+  settings[:puppet_runtime_location] = runtime_details['location']
+  settings[:puppet_runtime_basename] = "bolt-runtime-#{runtime_details['version']}.#{platform.name}"
+
+  settings_uri = File.join(runtime_details['location'], "#{proj.settings[:puppet_runtime_basename]}.settings.yaml")
+  sha1sum_uri = "#{settings_uri}.sha1"
+  proj.inherit_yaml_settings(settings_uri, sha1sum_uri)
 
   proj.description 'Stand alone task runner'
   proj.version_from_git


### PR DESCRIPTION
Switch from downloading the puppet-runtime git repo to get settings to
loading them from a yaml file published with the puppet-runtime package.