### PR TITLE
(BOLT-706) Update orchestrator-client gem to 0.3.1

### DIFF
--- a/configs/components/rubygem-orchestrator_client.rb
+++ b/configs/components/rubygem-orchestrator_client.rb
@@ -1,5 +1,5 @@
 component "rubygem-orchestrator_client" do |pkg, settings, platform|
-  pkg.version "0.3.0"
-  pkg.md5sum "e81d18cdf501e5995a1b963809cf37a3"
+  pkg.version "0.3.1"
+  pkg.md5sum "4d5dfb212be076c7a6dcdadb4a2ad7b5"
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end


### PR DESCRIPTION
Incorporates a fix for token files with trailing newlines.