### PR TITLE
(maint) Move service config to packaging, fix GEM_PATH

### DIFF
--- a/configs/components/pe-bolt-server.rb
+++ b/configs/components/pe-bolt-server.rb
@@ -16,10 +16,13 @@ component "pe-bolt-server" do |pkg, settings, platform|
 
   case platform.servicetype
   when "systemd"
-    pkg.install_service "ext/systemd/pe-bolt-server.service"
+    pkg.add_source("file://resources/systemd/pe-bolt-server.service", sum: "37bf640ee38c77ee8893badf9af6ad05")
+    pkg.install_service "../pe-bolt-server.service"
   when "sysv"
     if platform.is_rpm?
-      pkg.install_service "ext/redhat/pe-bolt-server.init", "ext/redhat/pe-bolt-server.sysconfig"
+      pkg.add_source("file://resources/redhat/pe-bolt-server.init", sum: "e59aafed20d3db5025f99f6345a3fd29")
+      pkg.add_source("file://resources/redhat/pe-bolt-server.sysconfig", sum: "273ddf6ee45968f2f96a0a7adc3b4a59")
+      pkg.install_service "../pe-bolt-server.init", "../pe-bolt-server.sysconfig"
     else
       fail "This OS is not supported. See https://puppet.com/docs/pe/latest/supported_operating_systems.html#puppet-master-platforms for supported platforms"
     end

--- a/resources/config/bolt-server.conf
+++ b/resources/config/bolt-server.conf
@@ -1,0 +1,6 @@
+bolt-server: {
+    port: 62658
+    ssl-cert: cert.pem
+    ssl-key: private_key.pem
+    ssl-ca-cert: ca.pem
+}

--- a/resources/redhat/pe-bolt-server.init
+++ b/resources/redhat/pe-bolt-server.init
@@ -1,0 +1,146 @@
+#!/bin/bash
+# PE Bolt Server    Bolt transport API
+#
+# chkconfig: - 98 02
+#
+# description: Service to expose bolt transport API
+# processname: bolt-server
+# config: /etc/sysconfig/pe-bolt-server
+
+# Source function library.
+. /etc/rc.d/init.d/functions
+
+#set default privileges to -rw-r-----
+umask 027
+
+[ -f /etc/sysconfig/pe-bolt-server ] && . /etc/sysconfig/pe-bolt-server
+
+prefix='/opt/puppetlabs/server/apps/bolt-server'
+export GEM_PATH="${prefix}/lib/ruby/gems/2.4.0:/opt/puppetlabs/puppet/lib/ruby/gems/2.4.0:/opt/puppetlabs/puppet/lib/ruby/vendor_gems"
+exec="${prefix}/bin/bolt-server"
+prog="bolt-server"
+desc="PE Bolt Server"
+owner="pe-bolt-server"
+
+lockfile=/var/lock/subsys/$prog
+piddir=/var/run/puppetlabs/$prog
+pidfile="${piddir}/${prog}.pid"
+logdir=/var/log/puppetlabs/$prog
+pid=$(cat $pidfile 2> /dev/null)
+RETVAL=0
+
+[ -x $exec ] || exit 5
+
+if status | grep -q -- '-p' 2>/dev/null; then
+    daemonopts="--pidfile $pidfile"
+    pidopts="-p $pidfile"
+    USEINITFUNCTIONS=true
+fi
+
+start() {
+    echo -n $"Starting PE Bolt Server: "
+    mkdir -p $piddir $logdir
+    daemon $daemonopts --user=$owner $exec -C "${prefix}/puma_config.rb" -d --pidfile $pidfile ${PE_BOLT_SERVER_OPTIONS}
+    RETVAL=$?
+    echo
+    [ $RETVAL = 0 ] && touch ${lockfile}
+    return $RETVAL
+}
+
+stop() {
+    echo -n $"Stopping PE Bolt Server: "
+    if [ "$USEINITFUNCTIONS" = "true" ]; then
+        killproc $pidopts $exec
+        RETVAL=$?
+    else
+        if [ -n "${pid}" ]; then
+            kill -TERM $pid >/dev/null 2>&1
+            RETVAL=$?
+        fi
+    fi
+    echo
+    [ $RETVAL = 0 ] && rm -f ${lockfile} ${pidfile}
+    return $RETVAL
+}
+
+reload() {
+    echo -n $"Reloading PE Bolt Server: "
+    if [ "$USEINITFUNCTIONS" = "true" ]; then
+        killproc $pidopts $exec -HUP
+        RETVAL=$?
+    else
+        if [ -n "${pid}" ]; then
+            kill -HUP $pid >/dev/null 2>&1
+            RETVAL=$?
+        else
+            RETVAL=0
+        fi
+    fi
+    echo
+    return $RETVAL
+}
+
+restart() {
+    stop
+    start
+}
+
+rh_status() {
+    if [ "$USEINITFUNCTIONS" = "true" ]; then
+        status $pidopts $exec
+        RETVAL=$?
+        return $RETVAL
+    else
+        if [ -n "${pid}" ]; then
+            if `ps -p $pid | grep $pid > /dev/null 2>&1`; then
+                echo "${desc} (pid ${pid}) is running..."
+                RETVAL=0
+                return $RETVAL
+            fi
+        fi
+        if [ -f "${pidfile}" ] ; then
+            echo "${desc} dead but pid file exists"
+            RETVAL=1
+            return $RETVAL
+        fi
+        if [ -f "${lockfile}" ]; then
+            echo "${desc} dead but subsys locked"
+            RETVAL=2
+            return $RETVAL
+        fi
+        echo "${desc} is stopped"
+        RETVAL=3
+        return $RETVAL
+    fi
+}
+
+rh_status_q() {
+    rh_status >/dev/null 2>&1
+}
+
+case "$1" in
+    start)
+        start
+    ;;
+    stop)
+        stop
+    ;;
+    restart)
+        restart
+    ;;
+    reload|force-reload)
+        reload
+    ;;
+    condrestart|try-restart)
+        rh_status_q || exit 0
+        restart
+    ;;
+    status)
+        rh_status
+    ;;
+    *)
+        echo $"Usage: $0 {start|stop|status|restart|condrestart}"
+        exit 1
+esac
+
+exit $RETVAL

--- a/resources/redhat/pe-bolt-server.sysconfig
+++ b/resources/redhat/pe-bolt-server.sysconfig
@@ -1,0 +1,2 @@
+# You may specify parameters to the PE Bolt Server here
+#PE_BOLT_SERVER_OPTIONS=--loglevel=debug

--- a/resources/systemd/pe-bolt-server.logrotate
+++ b/resources/systemd/pe-bolt-server.logrotate
@@ -1,0 +1,11 @@
+/var/log/puppetlabs/pe-bolt-service/*.log {
+    daily
+    missingok
+    rotate 30
+    compress
+    notifempty
+    sharedscripts
+    postrotate
+        systemctl is-active --quiet pe-bolt-server.service && systemctl kill --signal=USR2 --kill-who=main pe-bolt-server.service
+    endscript
+}

--- a/resources/systemd/pe-bolt-server.service
+++ b/resources/systemd/pe-bolt-server.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=PE Bolt Server
+After=syslog.target network.target
+
+[Service]
+User=pe-bolt-server
+Group=pe-bolt-server
+EnvironmentFile=-/etc/sysconfig/pe-bolt-server-service
+EnvironmentFile=-/etc/default/pe-bolt-server-service
+Environment=GEM_PATH=/opt/puppetlabs/server/apps/bolt-server/lib/ruby/gems/2.4.0:/opt/puppetlabs/puppet/lib/ruby/gems/2.4.0:/opt/puppetlabs/puppet/lib/ruby/vendor_gems
+ExecStart=/opt/puppetlabs/server/apps/bolt-server/bin/bolt-server -C /opt/puppetlabs/server/apps/bolt-server/puma_config.rb
+Restart=always
+#set default privileges to -rw-r-----
+UMask=027
+KillMode=process
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Move service config from the bolt repo to packaging.

Also GEM_HOME appears to be appended to GEM_PATH. If a different
version of Bolt is installed in puppet-agent, that impacts how
bolt-server functions. Set GEM_PATH instead to ensure we use the
bolt-server specific gems first.

This ties bolt-server's service config more closely to the puppet-agent
Ruby setup, since we have to include its GEM_PATH as well.