### PR TITLE
(BOLT-664) Update winrm-fs to 1.3.0

### DIFF
--- a/configs/components/rubygem-winrm-fs.rb
+++ b/configs/components/rubygem-winrm-fs.rb
@@ -1,5 +1,5 @@
 component "rubygem-winrm-fs" do |pkg, settings, platform|
-  pkg.version "1.2.1"
-  pkg.md5sum "40dd5e3ab75756b152ee14c4ece409c1"
+  pkg.version "1.3.0"
+  pkg.md5sum "190670971b9644938f462fe50b28ba96"
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end


### PR DESCRIPTION
Updated version of winrm-fs includes support for uploading StringIO object to remote file.