### PR TITLE
(BOLT-658) Add json-schema gem

### DIFF
--- a/configs/components/rubygem-json-schema.rb
+++ b/configs/components/rubygem-json-schema.rb
@@ -1,0 +1,5 @@
+component "rubygem-json-schema" do |pkg, settings, platform|
+  pkg.version "2.8.0"
+  pkg.md5sum "075b4034f57ee8ab900a92a8da45054a"
+  instance_eval File.read('configs/components/_base-rubygem.rb')
+end

--- a/configs/projects/pe-bolt-server.rb
+++ b/configs/projects/pe-bolt-server.rb
@@ -33,6 +33,7 @@ project "pe-bolt-server" do |proj|
   proj.instance_eval File.read('configs/projects/bolt-shared.rb')
 
   # Webserver dependencies
+  proj.component 'rubygem-json-schema'
   proj.component 'rubygem-rack'
   proj.component 'rubygem-tilt'
   proj.component 'rubygem-rack-protection'


### PR DESCRIPTION
The json-schema library is used to validate requests for the bolt-server api.