### PR TITLE
(BOLT-882) Update dependencies

### DIFF
--- a/configs/components/rubygem-rack-protection.rb
+++ b/configs/components/rubygem-rack-protection.rb
@@ -1,5 +1,5 @@
 component "rubygem-rack-protection" do |pkg, settings, platform|
-  pkg.version "2.0.3"
-  pkg.md5sum "14fc00b8817c662566c13a761914f58f"
+  pkg.version "2.0.4"
+  pkg.md5sum "17ef705c2812d7f984ed9c7ea4bdb7f2"
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-rubyzip.rb
+++ b/configs/components/rubygem-rubyzip.rb
@@ -1,5 +1,5 @@
 component "rubygem-rubyzip" do |pkg, settings, platform|
-  pkg.version "1.2.1"
-  pkg.md5sum "bbbc9e29550db0789736fe40fa70e485"
+  pkg.version "1.2.2"
+  pkg.md5sum "81b89aafafafb1f7f1f50796606aa290"
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-sinatra.rb
+++ b/configs/components/rubygem-sinatra.rb
@@ -1,5 +1,5 @@
 component "rubygem-sinatra" do |pkg, settings, platform|
-  pkg.version "2.0.3"
-  pkg.md5sum "7aa198199e60b4fd6521b39221908501"
+  pkg.version "2.0.4"
+  pkg.md5sum "35eb661337d209865f9ddbd6571973ce"
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end


### PR DESCRIPTION
Includes a fix for
https://access.redhat.com/security/cve/cve-2018-1000544 in rubyzip.