### PR TITLE
(BOLT-879) Remove net-ssh-krb gem

### DIFF
--- a/configs/components/rubygem-net-ssh-krb.rb
+++ b/configs/components/rubygem-net-ssh-krb.rb
@@ -1,6 +1,0 @@
-component "rubygem-net-ssh-krb" do |pkg, settings, platform|
-  pkg.version "0.4.0"
-  pkg.md5sum "a19209530717d3b1254aebb2ab230635"
-  instance_eval File.read('configs/components/_base-rubygem.rb')
-end
-

--- a/configs/projects/puppet-bolt.rb
+++ b/configs/projects/puppet-bolt.rb
@@ -40,7 +40,6 @@ project "puppet-bolt" do |proj|
 
   proj.component "bolt-runtime"
   proj.instance_eval File.read('configs/projects/bolt-shared.rb')
-  proj.component 'rubygem-net-ssh-krb'
   proj.component "bolt"
 
   proj.directory proj.prefix


### PR DESCRIPTION
**What this changes** Removes the net-ssh-krb gem from bolt packages
**Why** Incompatible licenses for distribution