### PR TITLE
(BOLT-380) Enable ed25519 support in net-ssh

### DIFF
--- a/configs/components/rubygem-bcrypt_pbkdf.rb
+++ b/configs/components/rubygem-bcrypt_pbkdf.rb
@@ -1,0 +1,5 @@
+component "rubygem-bcrypt_pbkdf" do |pkg, settings, platform|
+  pkg.version "1.0.0"
+  pkg.md5sum "5ce3ccb9d550b78a8bca4d208f7ee619"
+  instance_eval File.read('configs/components/_base-rubygem.rb')
+end

--- a/configs/components/rubygem-ed25519.rb
+++ b/configs/components/rubygem-ed25519.rb
@@ -1,0 +1,5 @@
+component "rubygem-ed25519" do |pkg, settings, platform|
+  pkg.version "1.2.4"
+  pkg.md5sum "ba27e98736828152d900dd14b429fc27"
+  instance_eval File.read('configs/components/_base-rubygem.rb')
+end

--- a/configs/projects/bolt-shared.rb
+++ b/configs/projects/bolt-shared.rb
@@ -3,6 +3,13 @@ proj.vendor "Puppet, Inc.  <info@puppet.com>"
 proj.homepage "https://www.puppet.com"
 proj.identifier "com.puppetlabs"
 
+# Building native gems on Windows has some issues right now.
+# Include for non-Windows platforms only.
+unless platform.is_windows?
+  proj.component 'rubygem-bcrypt_pbkdf'
+  proj.component 'rubygem-ed25519'
+end
+
 proj.component 'rubygem-public_suffix'
 proj.component 'rubygem-addressable'
 proj.component 'rubygem-concurrent-ruby'


### PR DESCRIPTION
Not included on Windows yet. The Ruby from puppet-runtime doesn't work
well for gems with C extensions, and I couldn't get ed25519 to compile.