### PR TITLE
(BOLT-985) Add plan executor to bolt-server package

### DIFF
--- a/configs/components/pe-bolt-server.rb
+++ b/configs/components/pe-bolt-server.rb
@@ -12,17 +12,17 @@ component "pe-bolt-server" do |pkg, settings, platform|
     ["#{settings[:gem_install]} bolt-*.gem"]
   end
 
-  pkg.install_file('puma_config.rb', "#{settings[:prefix]}/puma_config.rb")
+  pkg.install_file('config/puma_config.rb', "#{settings[:prefix]}/config/puma_config.rb")
 
   case platform.servicetype
   when "systemd"
-    pkg.add_source("file://resources/systemd/pe-bolt-server.service", sum: "b6894840038999f8667197b4733c2c1e")
+    pkg.add_source("file://resources/systemd/pe-bolt-server.service", sum: "35783549be1823f0d2746661076e75f0")
     pkg.add_source("file://resources/systemd/pe-bolt-server.logrotate", sum: "e3e77a174da30ab4eb0d55da04f9b31b")
     pkg.install_service "../pe-bolt-server.service"
     pkg.install_configfile "../pe-bolt-server.logrotate", "/etc/logrotate.d/pe-bolt-server"
   when "sysv"
     if platform.is_rpm?
-      pkg.add_source("file://resources/redhat/pe-bolt-server.init", sum: "48ca55616c992cc57405c6e6e2824ecb")
+      pkg.add_source("file://resources/redhat/pe-bolt-server.init", sum: "2ad1e120fa79f0d8bef8b3420dcfa229")
       pkg.add_source("file://resources/redhat/pe-bolt-server.sysconfig", sum: "273ddf6ee45968f2f96a0a7adc3b4a59")
       pkg.add_source("file://resources/redhat/pe-bolt-server.logrotate", sum: "47740a40b4c22b7d6129c51f03d14c96")
       pkg.install_service "../pe-bolt-server.init", "../pe-bolt-server.sysconfig"
@@ -36,9 +36,9 @@ component "pe-bolt-server" do |pkg, settings, platform|
 
   pkg.add_postinstall_action ["install", "upgrade"], [
     "/bin/chown -R #{settings[:pe_bolt_user]}:#{settings[:pe_bolt_user]} #{settings[:homedir]}",
-    "/bin/chown -R #{settings[:pe_bolt_user]}:#{settings[:pe_bolt_user]} #{settings[:sysconfdir]}",
-    "/bin/chown -R #{settings[:pe_bolt_user]}:#{settings[:pe_bolt_user]} #{settings[:logdir]}",
-    "/bin/chown -R #{settings[:pe_bolt_user]}:#{settings[:pe_bolt_user]} #{settings[:rundir]}"
+    "/bin/chown -R #{settings[:pe_bolt_user]}:#{settings[:pe_bolt_user]} #{settings[:bolt_sysconfdir]}",
+    "/bin/chown -R #{settings[:pe_bolt_user]}:#{settings[:pe_bolt_user]} #{settings[:bolt_logdir]}",
+    "/bin/chown -R #{settings[:pe_bolt_user]}:#{settings[:pe_bolt_user]} #{settings[:bolt_rundir]}"
   ]
   pkg.add_postinstall_action ["install"], [
     "systemctl daemon-reload"

--- a/configs/components/pe-plan-executor.rb
+++ b/configs/components/pe-plan-executor.rb
@@ -1,0 +1,46 @@
+component "pe-plan-executor" do |pkg, settings, platform|
+  pkg.environment "GEM_HOME", settings[:gem_home]
+  pkg.environment "PATH", "#{settings[:bindir]}:$$PATH"
+  pkg.load_from_json('configs/components/bolt.json')
+  pkg.build_requires 'puppet-agent'
+
+  pkg.build do
+    ["#{settings[:gem_build]} bolt.gemspec"]
+  end
+
+  pkg.install do
+    ["#{settings[:gem_install]} bolt-*.gem"]
+  end
+
+  pkg.install_file('config/plan_config.rb', "#{settings[:prefix]}/config/plan_config.rb")
+
+  case platform.servicetype
+  when "systemd"
+    pkg.add_source("file://resources/systemd/pe-plan-executor.service", sum: "4e9dcef15e682ff8a014d9f302da918a")
+    pkg.add_source("file://resources/systemd/pe-plan-executor.logrotate", sum: "32955ab713783650a515ec96ecbab51a")
+    pkg.install_service "../pe-plan-executor.service"
+    pkg.install_configfile "../pe-plan-executor.logrotate", "/etc/logrotate.d/pe-plan-executor"
+  when "sysv"
+    if platform.is_rpm?
+      pkg.add_source("file://resources/redhat/pe-plan-executor.init", sum: "30901f70cea4e979fb6cc928cb05090a")
+      pkg.add_source("file://resources/redhat/pe-plan-executor.sysconfig", sum: "b9ceca7286d4b82f677abd3584a2ee5e")
+      pkg.add_source("file://resources/redhat/pe-plan-executor.logrotate", sum: "70de9b844fcb4384e20067ae2ce2fba5")
+      pkg.install_service "../pe-plan-executor.init", "../pe-plan-executor.sysconfig"
+      pkg.install_configfile "../pe-plan-executor.logrotate", "/etc/logrotate.d/pe-plan-executor"
+    else
+      fail "This OS is not supported. See https://puppet.com/docs/pe/latest/supported_operating_systems.html#puppet-master-platforms for supported platforms"
+    end
+  else
+    fail "need to know where to put service files"
+  end
+
+  pkg.add_postinstall_action ["install", "upgrade"], [
+    "/bin/chown -R #{settings[:pe_bolt_user]}:#{settings[:pe_bolt_user]} #{settings[:homedir]}",
+    "/bin/chown -R #{settings[:pe_bolt_user]}:#{settings[:pe_bolt_user]} #{settings[:plan_sysconfdir]}",
+    "/bin/chown -R #{settings[:pe_bolt_user]}:#{settings[:pe_bolt_user]} #{settings[:plan_logdir]}",
+    "/bin/chown -R #{settings[:pe_bolt_user]}:#{settings[:pe_bolt_user]} #{settings[:plan_rundir]}"
+  ]
+  pkg.add_postinstall_action ["install"], [
+    "systemctl daemon-reload"
+  ]
+end

--- a/configs/projects/pe-bolt-server.rb
+++ b/configs/projects/pe-bolt-server.rb
@@ -4,11 +4,19 @@ project "pe-bolt-server" do |proj|
   # We can just have the same version as bolt, and use tags for specific packages
   proj.version_from_git
 
+  services = {"bolt-service" => "bolt", "plan-executor" => "plan"}
+
+  services.each do |service, short|
+    proj.setting("#{short}_sysconfdir".to_sym,
+                 "/etc/puppetlabs/#{service}/conf.d")
+    proj.setting("#{short}_logdir".to_sym,
+                 "/var/log/puppetlabs/#{service}")
+    proj.setting("#{short}_rundir".to_sym,
+                 "/var/run/puppetlabs/#{service}")
+  end
+
   proj.setting(:prefix, "/opt/puppetlabs/server/apps/bolt-server")
   proj.setting(:pe_bolt_user, "pe-bolt-server")
-  proj.setting(:sysconfdir, "/etc/puppetlabs/bolt-server/conf.d")
-  proj.setting(:logdir, "/var/log/puppetlabs/bolt-server")
-  proj.setting(:rundir, "/var/run/puppetlabs/bolt-server")
   proj.setting(:bindir, "#{proj.prefix}/bin")
   proj.setting(:libdir, "#{proj.prefix}/lib")
   proj.setting(:homedir, "/opt/puppetlabs/server/data/bolt-server")
@@ -45,7 +53,10 @@ project "pe-bolt-server" do |proj|
 
   proj.directory proj.prefix
   proj.directory proj.homedir
-  proj.directory proj.sysconfdir
-  proj.directory proj.logdir
-  proj.directory proj.rundir
+
+  services.each do |_, short|
+    proj.directory proj.send("#{short}_sysconfdir")
+    proj.directory proj.send("#{short}_logdir")
+    proj.directory proj.send("#{short}_rundir")
+  end
 end

--- a/resources/redhat/pe-plan-executor.init
+++ b/resources/redhat/pe-plan-executor.init
@@ -1,11 +1,11 @@
 #!/bin/bash
-# PE Bolt Server    Bolt transport API
+# PE Plan Executor      Bolt plan executor API
 #
 # chkconfig: - 98 02
 #
-# description: Service to expose bolt transport API
-# processname: bolt-server
-# config: /etc/sysconfig/pe-bolt-server
+# description: Service to expose bolt plans API
+# processname: plan-executor
+# config: /etc/sysconfig/pe-plan-executor
 
 # Source function library.
 . /etc/rc.d/init.d/functions
@@ -13,13 +13,14 @@
 #set default privileges to -rw-r-----
 umask 027
 
-[ -f /etc/sysconfig/pe-bolt-server ] && . /etc/sysconfig/pe-bolt-server
+[ -f /etc/sysconfig/pe-plan-executor ] && . /etc/sysconfig/pe-plan-executor
 
-prefix='/opt/puppetlabs/server/apps/bolt-server'
+prefix='/opt/puppetlabs/server/apps/plan-executor'
 export GEM_PATH="${prefix}/lib/ruby:/opt/puppetlabs/puppet/lib/ruby/gems/2.5.0:/opt/puppetlabs/puppet/lib/ruby/vendor_gems"
-exec="${prefix}/bin/bolt-server"
-prog="bolt-server"
-desc="PE Bolt Server"
+exec="${prefix}/bin/plan-executor"
+prog="plan-executor"
+desc="PE Plan Executor"
+# We reuse the bolt-server user for this service
 owner="pe-bolt-server"
 
 lockfile=/var/lock/subsys/$prog
@@ -38,9 +39,9 @@ if status | grep -q -- '-p' 2>/dev/null; then
 fi
 
 start() {
-    echo -n $"Starting PE Bolt Server: "
+    echo -n $"Starting PE Plan Executor: "
     mkdir -p $piddir $logdir
-    daemon $daemonopts --user=$owner $exec -C "${prefix}/config/puma_config.rb" -e production -d --pidfile $pidfile ${PE_BOLT_SERVER_OPTIONS}
+    daemon $daemonopts --user=$owner $exec -C "${prefix}/config/plan_config.rb" -e production -d --pidfile $pidfile ${PE_BOLT_SERVER_OPTIONS}
     RETVAL=$?
     echo
     [ $RETVAL = 0 ] && touch ${lockfile}
@@ -48,7 +49,7 @@ start() {
 }
 
 stop() {
-    echo -n $"Stopping PE Bolt Server: "
+    echo -n $"Stopping PE Plan Executor: "
     if [ "$USEINITFUNCTIONS" = "true" ]; then
         killproc $pidopts $exec
         RETVAL=$?
@@ -64,7 +65,7 @@ stop() {
 }
 
 reload() {
-    echo -n $"Reloading PE Bolt Server: "
+    echo -n $"Reloading PE Plan Executor: "
     if [ "$USEINITFUNCTIONS" = "true" ]; then
         killproc $pidopts $exec -HUP
         RETVAL=$?

--- a/resources/redhat/pe-plan-executor.logrotate
+++ b/resources/redhat/pe-plan-executor.logrotate
@@ -1,0 +1,11 @@
+/var/log/puppetlabs/plan-executor/*.log {
+    daily
+    missingok
+    rotate 30
+    compress
+    notifempty
+    sharedscripts
+    postrotate
+        if [ -s /var/run/puppetlabs/plan-executor/plan-executor.pid ]; then kill -HUP `cat /var/run/puppetlabs/plan-executor/plan-executor.pid`; fi
+    endscript
+}

--- a/resources/redhat/pe-plan-executor.sysconfig
+++ b/resources/redhat/pe-plan-executor.sysconfig
@@ -1,0 +1,2 @@
+# You may specify parameters to the PE Plan Executor here
+#PE_PLAN_EXECUTOR_OPTIONS=--loglevel=debug

--- a/resources/systemd/pe-bolt-server.service
+++ b/resources/systemd/pe-bolt-server.service
@@ -8,7 +8,7 @@ Group=pe-bolt-server
 EnvironmentFile=-/etc/sysconfig/pe-bolt-server-service
 EnvironmentFile=-/etc/default/pe-bolt-server-service
 Environment=GEM_PATH=/opt/puppetlabs/server/apps/bolt-server/lib/ruby:/opt/puppetlabs/puppet/lib/ruby/gems/2.5.0:/opt/puppetlabs/puppet/lib/ruby/vendor_gems
-ExecStart=/opt/puppetlabs/server/apps/bolt-server/bin/bolt-server -C /opt/puppetlabs/server/apps/bolt-server/puma_config.rb -e production
+ExecStart=/opt/puppetlabs/server/apps/bolt-server/bin/bolt-server -C /opt/puppetlabs/server/apps/bolt-server/config/puma_config.rb -e production
 Restart=always
 #set default privileges to -rw-r-----
 UMask=027

--- a/resources/systemd/pe-plan-executor.logrotate
+++ b/resources/systemd/pe-plan-executor.logrotate
@@ -1,0 +1,11 @@
+/var/log/puppetlabs/plan-executor/*.log {
+    daily
+    missingok
+    rotate 30
+    compress
+    notifempty
+    sharedscripts
+    postrotate
+        systemctl is-active --quiet pe-plan-executor.service && systemctl kill --signal=HUP --kill-who=main pe-plan-executor.service
+    endscript
+}

--- a/resources/systemd/pe-plan-executor.service
+++ b/resources/systemd/pe-plan-executor.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=PE Plan Executor
+After=syslog.target network.target
+
+[Service]
+User=pe-plan-executor
+Group=pe-plan-executor
+EnvironmentFile=-/etc/sysconfig/pe-plan-executor-service
+EnvironmentFile=-/etc/default/pe-plan-executor-service
+Environment=GEM_PATH=/opt/puppetlabs/server/apps/plan-executor/lib/ruby:/opt/puppetlabs/puppet/lib/ruby/gems/2.5.0:/opt/puppetlabs/puppet/lib/ruby/vendor_gems
+ExecStart=/opt/puppetlabs/server/apps/plan-executor/bin/plan-executor -C /opt/puppetlabs/server/apps/plan-executor/config/puma_config.rb -e production
+Restart=always
+#set default privileges to -rw-r-----
+UMask=027
+KillMode=process
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This adds the plan-executor application and service to the `pe-bolt-server` package. Since this package is expected to only be run and managed in PE, and these services are closely related (though not technically dependent on each other), it seemed prudent to just have one pipeline and package to build and ship them together. This PR adds plan-executor settings to the bolt-server project, adds a plan-executor component, and plan-executor service files.