### PR TITLE
(BOLT-1040) Build puppet-bolt on osx with homebrew formulas as non-root

### DIFF
--- a/configs/platforms/osx-10.13-x86_64.rb
+++ b/configs/platforms/osx-10.13-x86_64.rb
@@ -3,17 +3,21 @@ platform "osx-10.13-x86_64" do |plat|
   plat.servicedir '/Library/LaunchDaemons'
   plat.codename "highsierra"
 
-  plat.provision_with 'export HOMEBREW_NO_AUTO_UPDATE=true'
   plat.provision_with 'export HOMEBREW_NO_EMOJI=true'
   plat.provision_with 'export HOMEBREW_VERBOSE=true'
 
-  plat.provision_with 'curl http://pl-build-tools.delivery.puppetlabs.net/osx/homebrew_sierra.tar.gz | tar -x --strip 1 -C /usr/local -f -'
-  plat.provision_with 'curl http://pl-build-tools.delivery.puppetlabs.net/osx/patches/0001-Add-needs-cxx14.patch | patch -p0'
-  plat.provision_with 'ssh-keyscan github.delivery.puppetlabs.net >> ~/.ssh/known_hosts; /usr/local/bin/brew tap puppetlabs/brew-build-tools gitmirror@github.delivery.puppetlabs.net:puppetlabs-homebrew-build-tools'
-  plat.provision_with '/usr/local/bin/brew tap-pin puppetlabs/brew-build-tools'
-  plat.provision_with 'curl -o /usr/local/bin/osx-deps http://pl-build-tools.delivery.puppetlabs.net/osx/osx-deps; chmod 755 /usr/local/bin/osx-deps'
-  plat.provision_with '/usr/local/bin/osx-deps pkg-config'
-  plat.install_build_dependencies_with "/usr/local/bin/osx-deps "
+  plat.provision_with 'sudo dscl . -create /Users/test'
+  plat.provision_with 'sudo dscl . -create /Users/test UserShell /bin/bash'
+  plat.provision_with 'sudo dscl . -create /Users/test UniqueID 1001'
+  plat.provision_with 'sudo dscl . -create /Users/test PrimaryGroupID 1000'
+  plat.provision_with 'sudo dscl . -create /Users/test NFSHomeDirectory /Users/test'
+  plat.provision_with 'sudo dscl . -passwd /Users/test password'
+  plat.provision_with 'sudo dscl . -merge /Groups/admin GroupMembership test'
+  plat.provision_with 'echo "test ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/username'
+  plat.provision_with 'mkdir -p /etc/homebrew'
+  plat.provision_with 'cd /etc/homebrew'
+  plat.provision_with 'su test -c \'echo | /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"\''
+  plat.provision_with 'sudo chown -R test:admin /Users/test/Library/'
   plat.vmpooler_template "osx-1012-x86_64"
   plat.output_dir File.join("apple", "10.13", "PC1", "x86_64")
 end

--- a/configs/platforms/osx-10.14-x86_64.rb
+++ b/configs/platforms/osx-10.14-x86_64.rb
@@ -1,0 +1,23 @@
+platform "osx-10.14-x86_64" do |plat|
+  plat.servicetype 'launchd'
+  plat.servicedir '/Library/LaunchDaemons'
+  plat.codename "mojave"
+
+  plat.provision_with 'export HOMEBREW_NO_EMOJI=true'
+  plat.provision_with 'export HOMEBREW_VERBOSE=true'
+
+  plat.provision_with 'sudo dscl . -create /Users/test'
+  plat.provision_with 'sudo dscl . -create /Users/test UserShell /bin/bash'
+  plat.provision_with 'sudo dscl . -create /Users/test UniqueID 1001'
+  plat.provision_with 'sudo dscl . -create /Users/test PrimaryGroupID 1000'
+  plat.provision_with 'sudo dscl . -create /Users/test NFSHomeDirectory /Users/test'
+  plat.provision_with 'sudo dscl . -passwd /Users/test password'
+  plat.provision_with 'sudo dscl . -merge /Groups/admin GroupMembership test'
+  plat.provision_with 'echo "test ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/username'
+  plat.provision_with 'mkdir -p /etc/homebrew'
+  plat.provision_with 'cd /etc/homebrew'
+  plat.provision_with 'su test -c \'echo | /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"\''
+  plat.provision_with 'sudo chown -R test:admin /Users/test/Library/'
+  plat.vmpooler_template "osx-1012-x86_64"
+  plat.output_dir File.join("apple", "10.14", "PC1", "x86_64")
+end


### PR DESCRIPTION
Previously bolt was being packaged with an outdated snapshot of homebrew that did not require non-root user during build process. This commit uses updated homebrew formulas by setting up a non-root user for packaging. See https://tickets.puppetlabs.com/browse/PA-2334 for upstream puppet-agent work.