### PR TITLE
(BOLT-1100) Configure SSL with a bolt.bat wrapper

### DIFF
--- a/configs/components/bolt.rb
+++ b/configs/components/bolt.rb
@@ -20,10 +20,15 @@ component "bolt" do |pkg, settings, platform|
     # PowerShell Module
     pkg.add_source("file://resources/files/windows/PuppetBolt/PuppetBolt.psd1", sum: "f21e2bcfcb64da273e561e6066dce949")
     pkg.add_source("file://resources/files/windows/PuppetBolt/PuppetBolt.psm1", sum: "1ed17a54fd4df1032ea8d96c047ac623")
+    # bat files for cmd
+    pkg.add_source("file://resources/files/windows/environment.bat", sum: "7f1afc78153dddc2038859a8bb3ae678")
+    pkg.add_source("file://resources/files/windows/bolt.bat", sum: "79b9115e80481f336886aff98103cbd9")
 
     pkg.directory "#{settings[:datadir]}/PowerShell/Modules/PuppetBolt"
     pkg.install_file "../PuppetBolt.psd1", "#{settings[:datadir]}/PowerShell/Modules/PuppetBolt/PuppetBolt.psd1"
     pkg.install_file "../PuppetBolt.psm1", "#{settings[:datadir]}/PowerShell/Modules/PuppetBolt/PuppetBolt.psm1"
+    pkg.install_file "../environment.bat", "#{settings[:bindir]}/environment.bat"
+    pkg.install_file "../bolt.bat", "#{settings[:bindir]}/bolt.bat"
   else
     pkg.add_source("file://resources/files/posix/bolt_env_wrapper", sum: "644f069f275f44af277b20a2d0d279c6")
     bolt_exe = File.join(settings[:link_bindir], 'bolt')

--- a/resources/files/windows/bolt.bat
+++ b/resources/files/windows/bolt.bat
@@ -1,0 +1,6 @@
+@echo off
+SETLOCAL
+
+call "%~dp0environment.bat" %0 %*
+
+ruby -S -- bolt %*

--- a/resources/files/windows/environment.bat
+++ b/resources/files/windows/environment.bat
@@ -1,0 +1,17 @@
+@ECHO OFF
+REM This is the parent directory of the directory containing this script (resolves to :install_root/Bolt/bin)
+SET BOLT_DIR=%~dp0..
+
+REM Avoid the nasty \..\ littering the paths.
+SET BOLT_DIR=%PL_BASEDIR:\bin\..=%
+
+REM Add bolt's bindir to the PATH
+SET PATH=%BOLT_DIR%\bin:%PATH%
+
+REM Set the RUBY LOAD_PATH using the RUBYLIB environment variable
+SET RUBYLIB=%PBOLT_DIR%\lib;%RUBYLIB%
+
+REM Set SSL variables to ensure trusted locations are used
+SET SSL_CERT_FILE=%BOLT_DIR%\ssl\cert.pem
+SET SSL_CERT_DIR=%BOLT_DIR%\ssl\certs
+SET OPENSSL_CONF=%BOLT_DIR%\ssl\openssl.cnf


### PR DESCRIPTION
Previously, we were using the default bolt.bat wrapper script generated
by rubygems. That caused `bolt puppetfile install` to fail when run from
cmd on windows, because it didn't have the necessary environment
variables set to use our CA bundle and therefore it didn't trust the
forge.

We now install our own bolt.bat wrapper to set those environment
variables, following the puppet.bat example from the puppet-agent
package.