### PR TITLE
(BOLT-978) Package puppet-bolt for fedora

### DIFF
--- a/configs/platforms/fedora-28-x86_64.rb
+++ b/configs/platforms/fedora-28-x86_64.rb
@@ -1,0 +1,11 @@
+platform "fedora-28-x86_64" do |plat|
+  plat.servicedir "/usr/lib/systemd/system"
+  plat.defaultdir "/etc/sysconfig"
+  plat.servicetype "systemd"
+  plat.dist "fc28"
+
+  plat.provision_with "/usr/bin/dnf install -y --best --allowerasing autoconf automake rsync gcc make rpmdevtools rpm-libs"
+  plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/pl-build-tools-release-#{plat.get_os_name}-28.noarch.rpm"
+  plat.install_build_dependencies_with "/usr/bin/dnf install -y --best --allowerasing"
+  plat.vmpooler_template "fedora-28-x86_64"
+end

--- a/configs/platforms/fedora-29-x86_64.rb
+++ b/configs/platforms/fedora-29-x86_64.rb
@@ -1,0 +1,17 @@
+platform "fedora-29-x86_64" do |plat|
+  plat.servicedir "/usr/lib/systemd/system"
+  plat.defaultdir "/etc/sysconfig"
+  plat.servicetype "systemd"
+
+  plat.vmpooler_template "fedora-29-x86_64"
+  plat.dist "fc29"
+
+  packages = %w[
+    autoconf automake bzip2-devel gcc gcc-c++
+    make cmake pkgconfig readline-devel
+    rpm-libs rpmdevtools rsync swig zlib-devel
+  ]
+  plat.provision_with("/usr/bin/dnf install -y --best --allowerasing #{packages.join(' ')}")
+
+  plat.install_build_dependencies_with "/usr/bin/dnf install -y --best --allowerasing"
+end

--- a/configs/projects/puppet-bolt.rb
+++ b/configs/projects/puppet-bolt.rb
@@ -44,4 +44,19 @@ project "puppet-bolt" do |proj|
 
   proj.directory proj.prefix
   proj.directory proj.link_bindir
+
+  if platform.is_fedora? && platform.os_version.to_i >= 28
+    # Disable shebang mangling for certain paths inside PDK.
+    # See https://fedoraproject.org/wiki/Packaging:Guidelines#Shebang_lines
+    brp_mangle_shebangs_exclude_from = [
+      ".*/opt/puppetlabs/bolt/private/ruby/.*",
+      ".*/opt/puppetlabs/bolt/share/cache/ruby/.*",
+    ].join('|')
+
+    proj.package_override("# Disable shebang mangling of embedded Ruby stuff\n%global __brp_mangle_shebangs_exclude_from ^(#{brp_mangle_shebangs_exclude_from})$")
+
+    # Disable build-id generation since it's currently generating conflicts
+    # with system libgcc and libstdc++
+    proj.package_override("# Disable build-id generation to avoid conflicts\n%global _build_id_links none")
+  end
 end


### PR DESCRIPTION
This commit adds bolt packaging for fedora. Note that fedora 29 uses build tools in the fedora image instead of internal tools used by fedora 29.