### PR TITLE
Revert "(maint) Use ffi and minitar versions from puppet-runtime"

### DIFF
--- a/configs/components/rubygem-ffi.rb
+++ b/configs/components/rubygem-ffi.rb
@@ -1,0 +1,5 @@
+component "rubygem-ffi" do |pkg, settings, platform|
+  pkg.version "1.9.25"
+  pkg.md5sum "e8923807b970643d9e356a65038769ac"
+  instance_eval File.read('configs/components/_base-rubygem.rb')
+end

--- a/configs/components/rubygem-minitar.rb
+++ b/configs/components/rubygem-minitar.rb
@@ -1,0 +1,5 @@
+component "rubygem-minitar" do |pkg, settings, platform|
+  pkg.version "0.7"
+  pkg.md5sum "c005236a3b4f6c129fec14bbff720666"
+  instance_eval File.read('configs/components/_base-rubygem.rb')
+end

--- a/configs/projects/pe-bolt-server.rb
+++ b/configs/projects/pe-bolt-server.rb
@@ -34,6 +34,9 @@ project "pe-bolt-server" do |proj|
 
   # R10k dependency
   proj.component 'rubygem-gettext-setup'
+  # Bolt dependencies that aren't included in Puppet on our platforms yet
+  proj.component 'rubygem-ffi'
+  proj.component 'rubygem-minitar'
 
   proj.instance_eval File.read('configs/projects/bolt-shared.rb')
 


### PR DESCRIPTION
Reverts puppetlabs/bolt-vanagon#74 

The puppet-agent that pe-bolt-server installs against does not have the same ffi as in puppet-runtime.