### PR TITLE
(BOLT-978) Add git to fedora platforms

### DIFF
--- a/configs/platforms/fedora-28-x86_64.rb
+++ b/configs/platforms/fedora-28-x86_64.rb
@@ -4,7 +4,7 @@ platform "fedora-28-x86_64" do |plat|
   plat.servicetype "systemd"
   plat.dist "fc28"
 
-  plat.provision_with "/usr/bin/dnf install -y --best --allowerasing autoconf automake rsync gcc make rpmdevtools rpm-libs"
+  plat.provision_with "/usr/bin/dnf install -y --best --allowerasing autoconf automake rsync gcc make rpmdevtools rpm-libs git"
   plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/pl-build-tools-release-#{plat.get_os_name}-28.noarch.rpm"
   plat.install_build_dependencies_with "/usr/bin/dnf install -y --best --allowerasing"
   plat.vmpooler_template "fedora-28-x86_64"

--- a/configs/platforms/fedora-29-x86_64.rb
+++ b/configs/platforms/fedora-29-x86_64.rb
@@ -9,7 +9,7 @@ platform "fedora-29-x86_64" do |plat|
   packages = %w[
     autoconf automake bzip2-devel gcc gcc-c++
     make cmake pkgconfig readline-devel
-    rpm-libs rpmdevtools rsync swig zlib-devel
+    rpm-libs rpmdevtools rsync swig zlib-devel git
   ]
   plat.provision_with("/usr/bin/dnf install -y --best --allowerasing #{packages.join(' ')}")
 


### PR DESCRIPTION
Previously every module defined in bolt's Puppetfile was downloaded by r10k from the forge. When a module specified to be download from github in https://github.com/puppetlabs/bolt/pull/863 it was discovered that the fedora platforms need to be provisioned with git.