### PR TITLE
(BOLT-1128) Fix JSON in PowerShell CLI

### DIFF
--- a/resources/files/windows/PuppetBolt/PuppetBolt.psm1
+++ b/resources/files/windows/PuppetBolt/PuppetBolt.psm1
@@ -8,8 +8,22 @@ $env:RUBY_DIR = $env:BOLT_BASEDIR
 $env:SSL_CERT_FILE = "$($env:BOLT_BASEDIR)\ssl\cert.pem"
 $env:SSL_CERT_DIR = "$($env:BOLT_BASEDIR)\ssl\certs"
 
+function ConvertTo-BoltArgs {
+    param(
+        [psobject]$inputObject
+    )
+
+    $outputArgs = @()
+
+    foreach($arg in $inputObject){
+        $outputArgs += [string]$arg.replace('"','"""')
+    }
+
+    Write-Output $outputArgs
+}
+
 function bolt {
-    &$env:RUBY_DIR\bin\ruby -S -- $env:RUBY_DIR\bin\bolt $args
+    &$env:RUBY_DIR\bin\ruby -S -- $env:RUBY_DIR\bin\bolt (ConvertTo-BoltArgs -inputObject $args)
 }
 
 Export-ModuleMember -Function bolt -Variable *


### PR DESCRIPTION
Prior to this change, passing JSON as a parameter value to Bolt was a
bit difficult and prone to error because of the formatting requirements
involved with getting a properly escaped JSON string into Ruby.

This change finds any double quote characters in a string argument and
properly escapes them before passing them as arguments to Bolt. This
should help not only with passing JSON, but in any other situation where
a set of quotes needs to be faithfully represented to Bolt when coming
from a PowerShell CLI environment.