### PR TITLE
(BOLT-1106) Bump r10k major version

### DIFF
--- a/configs/components/rubygem-cri.rb
+++ b/configs/components/rubygem-cri.rb
@@ -1,5 +1,5 @@
 component "rubygem-cri" do |pkg, settings, platform|
-  pkg.version "2.6.1"
-  pkg.md5sum "657c231f411fc9b7f630dcb980517bce"
+  pkg.version "2.15.3"
+  pkg.md5sum "1e972707fc6eafdcb9f2a5928d0d488b"
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end

--- a/configs/components/rubygem-r10k.rb
+++ b/configs/components/rubygem-r10k.rb
@@ -1,5 +1,5 @@
 component "rubygem-r10k" do |pkg, settings, platform|
-  pkg.version "2.6.5"
-  pkg.md5sum "cdafd1663ab651ef06c1d28c30827521"
+  pkg.version "3.1.1"
+  pkg.md5sum "767b7a4b90bcb25fabb6edc424364514"
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end


### PR DESCRIPTION
Incorporate bug fixes and new features from r10k 3.1.1 into bolt packages. The `cri` gem also needs to be updated so satisfy new r10k version.