### PR TITLE
(BOLT-1076) Manually restore the reference to bolt

### DIFF
--- a/configs/components/bolt.json
+++ b/configs/components/bolt.json
@@ -1,1 +1,1 @@
-{"url":"https://github.com/donoghuc/bolt.git","ref":"BOLT-1076"}
+{"url":"git://github.com/puppetlabs/bolt.git","ref":"bdf47dcaeef7c18d5cf185c722c4ce7dcf817db1"}


### PR DESCRIPTION
In order to avoid bolt-vanagon CI failures in https://github.com/puppetlabs/bolt-vanagon/pull/82/commits/cfe0c542f5566c14d25aa2f6d422ee3488f6b935 a fork of the bolt project was referenced. This allowed the vanagon project to run, but after merging the corresponding PR to Bolt the job to update the reference failed to find the reference BOLT-1076 in the bolt project. This commit manually makes the update that the bolt component pipeline would have made.