### PR TITLE
(BOLT-645) Update puppet-resource_api to 1.8.1

### DIFF
--- a/configs/components/rubygem-puppet-resource_api.rb
+++ b/configs/components/rubygem-puppet-resource_api.rb
@@ -1,5 +1,5 @@
 component "rubygem-puppet-resource_api" do |pkg, settings, platform|
-  pkg.version "1.6.2"
-  pkg.md5sum "ba038d56be25c55affa2bda964acce34"
+  pkg.version "1.8.1"
+  pkg.md5sum "e6c189b1610180ce0fbd6be5073e77e7"
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end


### PR DESCRIPTION
In order to support apply on devices pull in the latest RSAPI gem.