### PR TITLE
(BOLT-1201) Build bolt package including simple plans

### DIFF
--- a/configs/components/bolt.json
+++ b/configs/components/bolt.json
@@ -1,1 +1,1 @@
-{"url":"git://github.com/puppetlabs/bolt.git","ref":"f7ac6ad693f58affedd96681363b70c50f1250b6"}
+{"url":"git://github.com/puppetlabs/bolt.git","ref":"BOLT-1150-simple-plans"}

--- a/configs/components/rubygem-puppet.rb
+++ b/configs/components/rubygem-puppet.rb
@@ -1,5 +1,13 @@
 component "rubygem-puppet" do |pkg, settings, platform|
-  pkg.version "6.0.4"
-  pkg.md5sum "2f0060f3b4cf4042a75581922a8e1bfe"
-  instance_eval File.read('configs/components/_base-rubygem.rb')
+  pkg.version "6.4.0"
+  pkg.md5sum "b3f9716c9c8889f95c66b33bb7445f63"
+  #instance_eval File.read('configs/components/_base-rubygem.rb')
+  pkg.environment "GEM_HOME", settings[:gem_home]
+  gemname = pkg.get_name.gsub('rubygem-', '')
+  pkg.url "http://builds.delivery.puppetlabs.net/puppet/6.4.0/artifacts/puppet-6.4.0.gem"
+  pkg.mirror "#{settings[:buildsources_url]}/#{gemname}-#{pkg.get_version}.gem"
+
+  pkg.install do
+    "#{settings[:gem_install]} #{gemname}-#{pkg.get_version}.gem"
+  end
 end


### PR DESCRIPTION
This modifies the bolt JSON metadata to point to the feature branch of the bolt repo that includes simple plans. It also modifies the puppet rubygem component to get the Puppet 6.4.0 gem package from http://builds.delivery.puppetlabs.net/puppet/6.4.0/artifacts/ instead of rubygems.org, where it hasn't been published yet.