### PR TITLE
(maint) Only use 2019.0 apt repo for ubuntu 14.04

### DIFF
--- a/configs/platforms/ubuntu-14.04-amd64.rb
+++ b/configs/platforms/ubuntu-14.04-amd64.rb
@@ -1,11 +1,9 @@
-peversion = IO.read('peversion').strip
 platform "ubuntu-14.04-amd64" do |plat|
   plat.servicedir "/etc/init.d"
   plat.defaultdir "/etc/default"
   plat.servicetype "sysv"
   plat.codename "trusty"
 
-  plat.add_build_repository "http://enterprise.delivery.puppetlabs.net/#{peversion}/repos/#{plat.get_name}/#{plat.get_name}.repo"
   plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-#{plat.get_codename}.deb"
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper rsync fakeroot git"
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends --force-yes "

--- a/configs/platforms/ubuntu-14.04-i386.rb
+++ b/configs/platforms/ubuntu-14.04-i386.rb
@@ -1,4 +1,3 @@
-peversion = IO.read('peversion').strip
 platform "ubuntu-14.04-i386" do |plat|
   plat.servicedir "/etc/init.d"
   plat.defaultdir "/etc/default"


### PR DESCRIPTION
2019.1 (kearney) does not support ubuntu 14.04. For the 14.04 platform, only use 2019.0 apt repo from enterprise.deleiver.pl.net.