### PR TITLE
(BOLT-1220) Package pe-bolt-server for el8

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -8,7 +8,7 @@ repo_name: 'puppet5'
 nonfinal_repo_name: 'puppet5-nightly'
 build_tar: FALSE
 deb_targets: 'xenial-amd64 bionic-amd64'
-rpm_targets: 'el-6-x86_64 el-7-x86_64 el-8-x86_64 sles-12-x86_64'
+rpm_targets: 'el-6-x86_64 el-7-x86_64 sles-12-x86_64'
 osx_signing_cert: "Developer ID Installer: PUPPET LABS, INC. (VKGLGN2B6Y)"
 osx_signing_keychain: "/Users/jenkins/Library/Keychains/signing.keychain"
 osx_signing_server: 'osx-signer.delivery.puppetlabs.net'


### PR DESCRIPTION
In order to manage separate `build_defaullts` (specifically `rpm_targets`) between 2019.0 and 2019.1 separate branches for bolt-vanagon will be used. The problem is that `rpm_targets` controls what repos package promotion targets https://jenkins-compose.delivery.puppetlabs.net/job/Package-Promotion/9774/ . 2019.0 will fail when el8 is set as an `rpm_target` and the package wont get promoted when el8 is excluded (see https://puppet.slack.com/archives/CF3DYM9SL/p1554847038464100 ). This commit sets the rpm_targets for johnson.

The plan will be to short term maintain a johnson branch and leave kearney + future pointed at master and long term to move the PE specific config to a separate vanagon project.