### PR TITLE
(maint) Do not disable shebang mangling for redhat 8

### DIFF
--- a/configs/projects/puppet-bolt.rb
+++ b/configs/projects/puppet-bolt.rb
@@ -61,14 +61,6 @@ project "puppet-bolt" do |proj|
   end
 
   if platform.name =~ /^el-(8)-.*/
-    # Disable shebang mangling for certain paths inside Bolt.
-    brp_mangle_shebangs_exclude_from = [
-      ".*/opt/puppetlabs/bolt/ssl/.*",
-      ".*/opt/puppetlabs/bolt/lib/ruby/.*"
-    ].join('|')
-
-    proj.package_override("# Disable shebang mangling of embedded Ruby stuff\n%global __brp_mangle_shebangs_exclude_from ^(#{brp_mangle_shebangs_exclude_from})$")
-
     # Disable build-id generation since it's currently generating conflicts
     # with system libgcc and libstdc++
     proj.package_override("# Disable build-id generation to avoid conflicts\n%global _build_id_links none")


### PR DESCRIPTION
Change to upstream vanagon desables all shebang mangling for redhat 8. This commit removes unncessary code.