### PR TITLE
(maint) Update base image to build osx 10.13/14

### DIFF
--- a/configs/platforms/osx-10.13-x86_64.rb
+++ b/configs/platforms/osx-10.13-x86_64.rb
@@ -18,6 +18,6 @@ platform "osx-10.13-x86_64" do |plat|
   plat.provision_with 'cd /etc/homebrew'
   plat.provision_with 'su test -c \'echo | /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"\''
   plat.provision_with 'sudo chown -R test:admin /Users/test/Library/'
-  plat.vmpooler_template "osx-1012-x86_64"
+  plat.vmpooler_template "osx-1013-x86_64"
   plat.output_dir File.join("apple", "10.13", "PC1", "x86_64")
 end

--- a/configs/platforms/osx-10.14-x86_64.rb
+++ b/configs/platforms/osx-10.14-x86_64.rb
@@ -18,6 +18,6 @@ platform "osx-10.14-x86_64" do |plat|
   plat.provision_with 'cd /etc/homebrew'
   plat.provision_with 'su test -c \'echo | /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"\''
   plat.provision_with 'sudo chown -R test:admin /Users/test/Library/'
-  plat.vmpooler_template "osx-1012-x86_64"
+  plat.vmpooler_template "osx-1014-x86_64"
   plat.output_dir File.join("apple", "10.14", "PC1", "x86_64")
 end


### PR DESCRIPTION
The upstream puppet-runtime project where we describe bolt-runtime switched to building osx 10.13 and 10.14 runtimes from 10.12 to their respective templated (osx image) versions. https://github.com/puppetlabs/puppet-runtime/commit/8c44fbb87abed15bd069ffef51b0a1eb4e1bfff4 this commit updates bolt-vanagon to build on updated templates to match those runtimes.