### PR TITLE
(maint) manually add updated bolt ref

### DIFF
--- a/configs/components/bolt.json
+++ b/configs/components/bolt.json
@@ -1,1 +1,1 @@
-{"url":"git://github.com/puppetlabs/bolt.git","ref":"2c75b2850a229850439cde382e172eddaec89ec8"}
+{"url":"git://github.com/puppetlabs/bolt.git","ref":"8c303e1f5a8c4b69bca97487e9e02386b6b23018"}


### PR DESCRIPTION
When we cut a new johnson branch we lost promoting bolt updates. This manually adds latest ref.