### PR TITLE
(maint) Fix runtime tarball name for pe-bolt-server

### DIFF
--- a/configs/projects/pe-bolt-server.rb
+++ b/configs/projects/pe-bolt-server.rb
@@ -12,7 +12,7 @@ project "pe-bolt-server" do |proj|
 
   proj.setting(:puppet_runtime_version, runtime_details['version'])
   proj.setting(:puppet_runtime_location, runtime_details['location'])
-  proj.setting(:puppet_runtime_basename, "pe-bolt-server-runtime-2019.0.x-#{runtime_details['version']}.#{platform.name}")
+  proj.setting(:puppet_runtime_basename, "pe-bolt-server-runtime-2019.1.x-#{runtime_details['version']}.#{platform.name}")
 
   settings_uri = File.join(runtime_details['location'], "#{proj.settings[:puppet_runtime_basename]}.settings.yaml")
   sha1sum_uri = "#{settings_uri}.sha1"


### PR DESCRIPTION
Forgot to check for this in the mergeup from the johnson branch -- this will be moot soon, since pe-bolt-server is moving to puppetlabs/pe-bolt-vanagon, but this will be necessary just to see CI pass before we do the removal.