### PR TITLE
(RE-12370) Update repo names

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -4,8 +4,8 @@ gpg_name: 'info@puppetlabs.com'
 gpg_key: '7F438280EF8D349F'
 sign_tar: FALSE
 vanagon_project: TRUE
-repo_name: 'puppet5'
-nonfinal_repo_name: 'puppet5-nightly'
+repo_name: 'puppet-enterprise-tools'
+nonfinal_repo_name: 'puppet-nightly'
 build_tar: FALSE
 deb_targets: 'xenial-amd64 bionic-amd64'
 rpm_targets: 'el-6-x86_64 el-7-x86_64 el-8-x86_64 sles-12-x86_64'


### PR DESCRIPTION
This commit updates the `repo_name` param to `puppet-enterprise-tools`. This is
a new repo that will contain non-Puppet-Platform tools (like Bolt) for use by
PE customers. Even though we explicitly override this variable at ship time,
this is a good sane default.