### PR TITLE
(maint) Do not try to use latest system packages for el8

### DIFF
--- a/configs/platforms/el-8-x86_64.rb
+++ b/configs/platforms/el-8-x86_64.rb
@@ -4,7 +4,7 @@ platform "el-8-x86_64" do |plat|
   plat.servicetype "systemd"
 
   plat.provision_with "rpm --import http://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs"
-  plat.provision_with "yum install --assumeyes autoconf automake rsync gcc createrepo make rpmdevtools rpm-libs yum-utils rpm-sign libtool git"
+  plat.provision_with "yum install --nobest --assumeyes autoconf automake rsync gcc createrepo make rpmdevtools rpm-libs yum-utils rpm-sign libtool git"
   plat.install_build_dependencies_with "yum install --assumeyes"
   plat.vmpooler_template "redhat-8-x86_64"
 end


### PR DESCRIPTION
After moving from the beta Redhat8 to the official released version some of the pre-canned versions of core packages (like rpm and gcc) are to 'new' to be used with additional packages installed to build RPMs. This commit adds the --nobest cli option to not force the package manager to use the newest packages.