### PR TITLE
(BOLT-1303) Initial work to add a `puppet-bolt` docker container

### DIFF
--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -1,0 +1,1 @@
+TEST-rspec.xml

--- a/docker/.rspec
+++ b/docker/.rspec
@@ -1,0 +1,4 @@
+--require pupperware/spec_helper
+--format RspecJunitFormatter
+--out TEST-rspec.xml
+--format documentation

--- a/docker/Gemfile
+++ b/docker/Gemfile
@@ -1,0 +1,8 @@
+source ENV['GEM_SOURCE'] || "https://rubygems.org"
+
+gem 'rspec'
+gem 'rspec_junit_formatter'
+gem 'pupperware',
+  :git => 'https://github.com/puppetlabs/pupperware.git',
+  :ref => 'master',
+  :glob => 'gem/*.gemspec'

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,0 +1,45 @@
+NAMESPACE ?= puppet
+git_describe = $(shell git describe)
+vcs_ref := $(shell git rev-parse HEAD)
+build_date := $(shell date -u +%FT%T)
+hadolint_available := $(shell hadolint --help > /dev/null 2>&1; echo $$?)
+hadolint_command := hadolint --ignore DL3008 --ignore DL3018 --ignore DL4000 --ignore DL4001
+hadolint_container := hadolint/hadolint:latest
+pwd := $(shell pwd)
+export BUNDLE_PATH = $(pwd)/.bundle/gems
+export BUNDLE_BIN = $(pwd)/.bundle/bin
+export GEMFILE = $(pwd)/Gemfile
+
+version = $(shell echo $(git_describe) | sed 's/-.*//')
+dockerfile := Dockerfile
+
+prep:
+	@git fetch --unshallow > /dev/null 2>&1 ||:
+	@git fetch origin 'refs/tags/*:refs/tags/*'
+
+lint:
+ifeq ($(hadolint_available),0)
+	@$(hadolint_command) puppet-bolt/$(dockerfile)
+else
+	@docker pull $(hadolint_container)
+	@docker run --rm -v $(PWD)/puppet-bolt/$(dockerfile):/Dockerfile -i $(hadolint_container) $(hadolint_command) Dockerfile
+endif
+
+build: prep
+	@docker build --pull --build-arg vcs_ref=$(vcs_ref) --build-arg build_date=$(build_date) --build-arg version=$(version) --file puppet-bolt/$(dockerfile) --tag $(NAMESPACE)/puppet-bolt:$(version) puppet-bolt
+ifeq ($(IS_LATEST),true)
+	@docker tag $(NAMESPACE)/puppet-bolt:$(version) $(NAMESPACE)/puppet-bolt:latest
+endif
+
+test: prep
+	@bundle install --path $$BUNDLE_PATH --gemfile $$GEMFILE
+	@PUPPET_TEST_DOCKER_IMAGE=$(NAMESPACE)/puppet-bolt:$(version) \
+		bundle exec --gemfile $$GEMFILE rspec puppet-bolt/spec
+
+publish: prep
+	@docker push $(NAMESPACE)/puppet-bolt:$(version)
+ifeq ($(IS_LATEST),true)
+	@docker push $(NAMESPACE)/puppet-bolt:latest
+endif
+
+.PHONY: lint build test publish

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,179 @@
+# Puppet-bolt container
+
+Puppet Bolt it available as a docker image. This document covers some possible ways to use the container.
+
+## Building and Test
+
+A makefile is provided for building and testing the puppet-bolt container. Execute `make build` to build the latest or `make test` to run the tests.
+
+## Completely stand-alone
+
+When running Bolt from the container, the `localhost` target is the container environment (not the docker host environment). The following example shows running a command against the localhost target in the container.
+```
+cas@cas-ThinkPad-T460p:~/working_dir/docker_bolt$ docker run puppet-bolt command run 'cat /etc/os-release' -t localhost
+Started on localhost...
+Finished on localhost:
+  STDOUT:
+    NAME="Ubuntu"
+    VERSION="16.04.6 LTS (Xenial Xerus)"
+    ID=ubuntu
+    ID_LIKE=debian
+    PRETTY_NAME="Ubuntu 16.04.6 LTS"
+    VERSION_ID="16.04"
+    HOME_URL="http://www.ubuntu.com/"
+    SUPPORT_URL="http://help.ubuntu.com/"
+    BUG_REPORT_URL="http://bugs.launchpad.net/ubuntu/"
+    VERSION_CODENAME=xenial
+    UBUNTU_CODENAME=xenial
+Successful on 1 node: localhost
+Ran on 1 node in 0.00 seconds
+```
+In order to pass connection information and custom module content we need to share data from the host with the container. The following sections describe some ways to accomplish sharing data with the puppet Bolt container.
+
+## Pass Inventory as an environment variable
+
+In the case where no custom module content is required for the Bolt action you wish to execute with the container and the only information you need is how to connect to targets you can pass inventory as an enviornment variable. The following inventory has all the information needed to connect to the example target. 
+
+```yaml
+---
+nodes:
+  - name: pnz2rzpxfzp95hh.delivery.puppetlabs.net
+    alias: docker-example
+    config:
+      transport: ssh
+      ssh:
+        user: root
+        password: secret-password
+        host-key-check: false
+```
+The following invocation shows an example of running the built-in `facts` task against the target listed in inventory. 
+```
+cas@cas-ThinkPad-T460p:~/working_dir/docker_bolt$ docker run --env "BOLT_INVENTORY=$(cat Boltdir/inventory.yaml)" puppet-bolt task run facts -t docker-example
+Started on pnz2rzpxfzp95hh.delivery.puppetlabs.net...
+Finished on pnz2rzpxfzp95hh.delivery.puppetlabs.net:
+  {
+    "os": {
+      "name": "CentOS",
+      "release": {
+        "full": "7.2",
+        "major": "7",
+        "minor": "2"
+      },
+      "family": "RedHat"
+    }
+  }
+Successful on 1 node: pnz2rzpxfzp95hh.delivery.puppetlabs.net
+Ran on 1 node in 0.55 seconds
+```
+## Mount Bolt project directory from host 
+
+This section describes making a Bolt project directory (Boltdir) available to the container. The directory structure and relevant file content is listed below:
+```
+cas@cas-ThinkPad-T460p:~/working_dir/docker_bolt$ tree
+.
+└── Boltdir
+    ├── bolt.yaml
+    ├── inventory.yaml
+    ├── keys
+    │   └── id_rsa-acceptance
+    └── site-modules
+        └── docker_task
+            └── tasks
+                └── init.sh
+
+5 directories, 4 files
+```
+**bolt.yaml**
+
+Bolt configuration file
+```yaml
+---
+log:
+  console:
+    level: notice
+```
+**inventory.yaml**
+
+Store information about targets. Note the absolute path to the private key is the path in the container not the host.
+```yaml
+---
+nodes:
+  - name: pnz2rzpxfzp95hh.delivery.puppetlabs.net
+    alias: docker-example
+    config:
+      transport: ssh
+      ssh:
+        user: root
+        private-key: /Boltdir/keys/id_rsa-acceptance
+        host-key-check: false
+```
+**init.sh**
+
+Example shell task that echos a `message` parameter.
+```bash
+#!/bin/bash
+echo "Message: ${PT_message}"
+```
+In order to execute the task with docker and provide all the information provided in the Bolt project directory it is possible to mount the Boltdir on the host with the following invocation:
+```
+cas@cas-ThinkPad-T460p:~/working_dir/docker_bolt$ docker run --mount type=bind,source=/home/cas/working_dir/docker_bolt/Boltdir,destination=/Boltdir puppet-bolt task run docker_task message=hi -t docker-example
+Started on pnz2rzpxfzp95hh.delivery.puppetlabs.net...
+Finished on pnz2rzpxfzp95hh.delivery.puppetlabs.net:
+  Message: hi
+  {
+  }
+Successful on 1 node: pnz2rzpxfzp95hh.delivery.puppetlabs.net
+Ran on 1 node in 0.56 seconds
+```
+
+The `--mount` flag maps the local directory to the root directory in the container (the working directory), the container is tagged as `puppet-bolt` and the rest of the invocation are all native to Bolt. 
+
+## Building on top of the puppet-bolt image
+
+You can also extend the puppet-bolt image and copy in data that will always be available for that image. In order to illustrate this we can add a Dockerfile to the directory structure defined in the previous example with the following content:
+```
+cas@cas-ThinkPad-T460p:~/working_dir/docker_bolt$ tree
+.
+└── Boltdir
+    ├── bolt.yaml
+    ├── Dockerfile
+    ├── inventory.yaml
+    ├── keys
+    │   └── id_rsa-acceptance
+    └── site-modules
+        └── docker_task
+            └── tasks
+                └── init.sh
+
+5 directories, 5 files
+```
+
+**Dockerfile**
+
+```Dockerfile
+FROM puppet-bolt
+
+COPY . /Boltdir
+```
+The following invocation shows building a container image with our custom module content and tagging it `my-extended-puppet-bolt`. 
+```
+cas@cas-ThinkPad-T460p:~/working_dir/docker_bolt/Boltdir$ docker build . -t my-extended-puppet-bolt
+Sending build context to Docker daemon  10.75kB
+Step 1/2 : FROM puppet-bolt
+ ---> 5d8d2c1166fc
+Step 2/2 : COPY . /Boltdir
+ ---> 03162d29a1ee
+Successfully built 03162d29a1ee
+Successfully tagged my-extended-puppet-bolt:latest
+```
+You can now run that container with the custom module content and connection information available inside the container. For example:
+```
+cas@cas-ThinkPad-T460p:~/working_dir/docker_bolt/Boltdir$ docker run my-extended-puppet-bolt task run docker_task message=hi -t docker-example
+Started on pnz2rzpxfzp95hh.delivery.puppetlabs.net...
+Finished on pnz2rzpxfzp95hh.delivery.puppetlabs.net:
+  Message: hi
+  {
+  }
+Successful on 1 node: pnz2rzpxfzp95hh.delivery.puppetlabs.net
+Ran on 1 node in 0.56 seconds
+```

--- a/docker/distelli-manifest.yml
+++ b/docker/distelli-manifest.yml
@@ -1,0 +1,9 @@
+pe-and-platform/puppet-bolt:
+  PreBuild:
+    - make lint
+  Build:
+    - make build PUPPERWARE_ANALYTICS_STREAM=production
+    - make test
+  AfterBuildSuccess:
+    - docker login -u "$DISTELLI_DOCKER_USERNAME" -p "$DISTELLI_DOCKER_PW" "$DISTELLI_DOCKER_ENDPOINT"
+    - make publish

--- a/docker/puppet-bolt/Dockerfile
+++ b/docker/puppet-bolt/Dockerfile
@@ -1,0 +1,40 @@
+FROM ubuntu:16.04
+
+ARG version="1.24.0"
+ARG vcs_ref
+ARG build_date
+
+ENV BOLT_VERSION="$version"
+ENV UBUNTU_CODENAME="xenial"
+ENV BOLT_DISABLE_ANALYTICS="true"
+
+LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
+      org.label-schema.vendor="Puppet" \
+      org.label-schema.url="https://github.com/puppetlabs/bolt-vanagon" \
+      org.label-schema.name="Puppet Bolt" \
+      org.label-schema.license="Apache-2.0" \
+      org.label-schema.version=$BOLT_VERSION \
+      org.label-schema.vcs-url="https://github.com/puppetlabs/bolt-vanagon" \
+      org.label-schema.vcs-ref="vcs_ref" \
+      org.label-schema.build-date="build_date" \
+      org.label-schema.schema-version="1.0" \
+      org.label-schema.dockerfile="/Dockerfile"
+
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y wget ca-certificates lsb-release && \
+    wget http://apt.puppetlabs.com/puppet-enterprise-tools-release-"$UBUNTU_CODENAME".deb && \
+    dpkg -i puppet-enterprise-tools-release-"$UBUNTU_CODENAME".deb && \
+    rm puppet-enterprise-tools-release-"$UBUNTU_CODENAME".deb && \
+    apt-get update && \
+    apt-get install --no-install-recommends -y puppet-bolt="$BOLT_VERSION"-1"$UBUNTU_CODENAME" && \
+    apt-get remove --purge -y wget && \
+    apt-get autoremove -y && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV PATH=/opt/puppetlabs/bin:$PATH
+
+ENTRYPOINT ["/opt/puppetlabs/bin/bolt"]
+CMD ["help"]
+
+COPY Dockerfile /

--- a/docker/puppet-bolt/spec/dockerfile_spec.rb
+++ b/docker/puppet-bolt/spec/dockerfile_spec.rb
@@ -1,0 +1,34 @@
+require 'rspec/core'
+SPEC_DIRECTORY = File.dirname(__FILE__)
+
+describe 'puppet-bolt container' do
+  include Pupperware::SpecHelpers
+
+  before(:all) do
+    @image = ENV['PUPPET_TEST_DOCKER_IMAGE']
+    if @image.nil?
+      error_message = <<-MSG
+* * * * *
+  PUPPET_TEST_DOCKER_IMAGE environment variable must be set so we
+  know which image to test against!
+* * * * *
+      MSG
+      fail error_message
+    end
+  end
+
+  it 'should run the image' do
+    result = run_command("docker run --detach #{@image}")
+    container = result[:stdout].chomp
+    wait_on_container_exit(container)
+    expect(get_container_exit_code(container)).to eq(0)
+    emit_log(container)
+    teardown_container(container)
+  end
+
+  it 'should run a bolt command and analytics should be disabled' do
+    result = run_command("docker run -i #{@image} command run whoami -t localhost --debug 2>&1")
+    expect(result[:stdout]).to match(/root/)
+    expect(result[:stdout]).to match(/Analytics opt-out is set, analytics will be disabled/)
+  end
+end


### PR DESCRIPTION
This uses the same tooling / pattern as the puppet-agent-ubuntu
container. Would eventually want this set up in jenkins I think, but the
pipelines config was trivial to copy over so I stuck with that for now.

Still todo:
- [x] Is this a reasonable command to run?
- [x] what volume mounts do we need?
- [x] do we need to copy over any configs?
- [x] other ENV variables to expose in the container / bolt config?
- [x] more thorough testing (blocked on better understanding of how the container will be used)
- [x] container docs