### PR TITLE
(BOLT-1339) Add support for redhatfips-7-x86_64

### DIFF
--- a/configs/platforms/redhatfips-7-x86_64.rb
+++ b/configs/platforms/redhatfips-7-x86_64.rb
@@ -1,0 +1,10 @@
+platform "redhatfips-7-x86_64" do |plat|
+  plat.servicedir "/usr/lib/systemd/system"
+  plat.defaultdir "/etc/sysconfig"
+  plat.servicetype "systemd"
+
+  plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/pl-build-tools-release-el-7.noarch.rpm"
+  plat.provision_with "yum install --assumeyes autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign"
+  plat.install_build_dependencies_with "yum install --assumeyes"
+  plat.vmpooler_template "redhat-fips-7-x86_64"
+end

--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -8,7 +8,7 @@ repo_name: 'puppet-enterprise-tools'
 nonfinal_repo_name: 'puppet-nightly'
 build_tar: FALSE
 deb_targets: 'xenial-amd64 bionic-amd64'
-rpm_targets: 'el-6-x86_64 el-7-x86_64 el-8-x86_64 sles-12-x86_64'
+rpm_targets: 'el-6-x86_64 el-7-x86_64 el-8-x86_64 redhatfips-7-x86_64 sles-12-x86_64'
 osx_signing_cert: "Developer ID Installer: PUPPET LABS, INC. (VKGLGN2B6Y)"
 osx_signing_keychain: "/Users/jenkins/Library/Keychains/signing.keychain"
 osx_signing_server: 'osx-signer.delivery.puppetlabs.net'


### PR DESCRIPTION
Relies on https://github.com/puppetlabs/puppet-runtime/pull/186 to get a bolt-runtime made for redhatfips-7-x86_64 so we can test a build

Relates to: https://github.com/puppetlabs/ci-job-configs/pull/5999