### PR TITLE
(BOLT-1317) Update build_defaults for shipping gem

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -1,5 +1,7 @@
 ---
 project: 'puppet-bolt'
+gem_name: 'bolt'
+build_gem: TRUE
 gpg_name: 'info@puppetlabs.com'
 gpg_key: '7F438280EF8D349F'
 sign_tar: FALSE


### PR DESCRIPTION
This commit adds some metadata for the ship_gem rake task to be able to ship a staged gem from builds.delivery.pl.net to rubygems.