### PR TITLE
(PA_2757) Temporarily pin python for 32bit debian 8

### DIFF
--- a/configs/platforms/debian-8-i386.rb
+++ b/configs/platforms/debian-8-i386.rb
@@ -6,7 +6,10 @@ platform "debian-8-i386" do |plat|
 
   plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-#{plat.get_codename}.deb"
 
-  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper rsync fakeroot git"
+  # FIXME: revert the following line once PA-2752 gets fixed upstream
+  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends " \
+                      "python3.4=3.4.2-1 python3.4-minimal=3.4.2-1 libpython3.4-stdlib=3.4.2-1 libpython3.4-minimal=3.4.2-1 " \
+                      "build-essential devscripts make quilt pkg-config debhelper rsync fakeroot git"
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends --force-yes "
   plat.vmpooler_template "debian-8-i386"
 end


### PR DESCRIPTION
This commit works around https://www.mail-archive.com/debian-bugs-dist@lists.debian.org/msg1685477.html , revert once upstream provider release a fix.