### PR TITLE
(BOLT-1407) Update apt-repo to pull bolt package from for dockerfile

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -10,7 +10,14 @@ export BUNDLE_PATH = $(pwd)/.bundle/gems
 export BUNDLE_BIN = $(pwd)/.bundle/bin
 export GEMFILE = $(pwd)/Gemfile
 
-version = $(shell echo $(git_describe) | sed 's/-.*//')
+# Check if ref is set in environment variable
+ifeq ("${REF}","")
+    version := $(shell echo $(git_describe) | sed 's/-.*//')
+else
+    version:= "${REF}"
+endif
+$(info    VERSION is $(version))
+
 dockerfile := Dockerfile
 
 prep:

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -6,17 +6,33 @@ hadolint_available := $(shell hadolint --help > /dev/null 2>&1; echo $$?)
 hadolint_command := hadolint --ignore DL3008 --ignore DL3018 --ignore DL4000 --ignore DL4001
 hadolint_container := hadolint/hadolint:latest
 pwd := $(shell pwd)
-export BUNDLE_PATH = $(pwd)/.bundle/gems
-export BUNDLE_BIN = $(pwd)/.bundle/bin
-export GEMFILE = $(pwd)/Gemfile
 
 # Check if ref is set in environment variable
+# REF is set by the CJC build-and-puahs-bolt-docker-image.sh script and 
+# is expected to be the Git Tag that represents the
+# bolt release version.
 ifeq ("${REF}","")
     version := $(shell echo $(git_describe) | sed 's/-.*//')
 else
     version:= "${REF}"
 endif
-$(info    VERSION is $(version))
+$(info VERSION is $(version))
+# # Alow bundler args to be configured with environment variables
+# # Add defaults based on running from Makefile dir.
+ifeq ("${BUNDLE_PATH}","")
+	export BUNDLE_PATH=$(pwd)/.bundle/gems
+endif
+$(info BUNDLE_PATH is "${BUNDLE_PATH}")
+
+ifeq ("${BUNDLE_BIN}","")
+	export BUNDLE_BIN=$(pwd)/.bundle/bin
+endif
+$(info BUNDLE_BIN is "${BUNDLE_BIN}")
+
+ifeq ("${GEMFILE}","")
+	export GEMFILE=$(pwd)/Gemfile
+endif
+$(info GEMFILE is "${GEMFILE}")
 
 dockerfile := Dockerfile
 
@@ -41,7 +57,7 @@ endif
 test: prep
 	@bundle install --path $$BUNDLE_PATH --gemfile $$GEMFILE
 	@PUPPET_TEST_DOCKER_IMAGE=$(NAMESPACE)/puppet-bolt:$(version) \
-		bundle exec --gemfile $$GEMFILE rspec puppet-bolt/spec
+		bundle exec rspec puppet-bolt/spec
 
 publish: prep
 	@docker push $(NAMESPACE)/puppet-bolt:$(version)

--- a/docker/puppet-bolt/Dockerfile
+++ b/docker/puppet-bolt/Dockerfile
@@ -22,9 +22,9 @@ LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
 
 RUN apt-get update && \
     apt-get install --no-install-recommends -y wget ca-certificates lsb-release && \
-    wget http://apt.puppetlabs.com/puppet-enterprise-tools-release-"$UBUNTU_CODENAME".deb && \
-    dpkg -i puppet-enterprise-tools-release-"$UBUNTU_CODENAME".deb && \
-    rm puppet-enterprise-tools-release-"$UBUNTU_CODENAME".deb && \
+    wget http://apt.puppetlabs.com/puppet-tools-release-"$UBUNTU_CODENAME".deb && \
+    dpkg -i puppet-tools-release-"$UBUNTU_CODENAME".deb && \
+    rm puppet-tools-release-"$UBUNTU_CODENAME".deb && \
     apt-get update && \
     apt-get install --no-install-recommends -y puppet-bolt="$BOLT_VERSION"-1"$UBUNTU_CODENAME" && \
     apt-get remove --purge -y wget && \


### PR DESCRIPTION
Previously the puppet-enterprise-tools-release path was used for apt release repos. The `enterprise` string has been removed. This commit updates the dockerfile to pull from the updated repo path.