### PR TITLE
(GH-1172) Make bolt-inventory-pdb executable out of the box

### DIFF
--- a/configs/components/bolt.rb
+++ b/configs/components/bolt.rb
@@ -27,14 +27,18 @@ component "bolt" do |pkg, settings, platform|
     pkg.install_file "../PuppetBolt.psm1", "#{settings[:datadir]}/PowerShell/Modules/PuppetBolt/PuppetBolt.psm1"
   else
     pkg.add_source("file://resources/files/posix/bolt_env_wrapper", sum: "644f069f275f44af277b20a2d0d279c6")
+    pkg.add_source("file://resources/files/posix/bolt_inventory_pdb_wrapper", sum: "5473e5169ed05c8e63ef3e520b3b8c65")
     bolt_exe = File.join(settings[:link_bindir], 'bolt')
+    bolt_inventory_pdb_exe = File.join(settings[:link_bindir], 'bolt-inventory-pdb')
     pkg.install_file "../bolt_env_wrapper", bolt_exe, mode: "0755"
+    pkg.install_file "../bolt_inventory_pdb_wrapper", bolt_inventory_pdb_exe, mode: "0755"
 
     if platform.is_macos?
       pkg.add_source 'file://resources/files/paths.d/50-bolt', sum: '4abf75aebbbfbbefc4fe0173c57ed0b2'
       pkg.install_file('../50-bolt', '/etc/paths.d/50-bolt')
     else
       pkg.link bolt_exe, File.join(settings[:main_bin], 'bolt')
+      pkg.link bolt_inventory_pdb_exe, File.join(settings[:main_bin], 'bolt-inventory-pdb')
     end
   end
 end

--- a/resources/files/posix/bolt_inventory_pdb_wrapper
+++ b/resources/files/posix/bolt_inventory_pdb_wrapper
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# avoid influences from already pre-configured other ruby environments
+env -u GEM_HOME -u GEM_PATH -u DLN_LIBRARY_PATH -u RUBYLIB -u RUBYLIB_PREFIX -u RUBYOPT -u RUBYPATH -u RUBYSHELL -u LD_LIBRARY_PATH -u LD_PRELOAD SHELL=/bin/sh /opt/puppetlabs/bolt/bin/bolt-inventory-pdb "$@"

--- a/resources/files/windows/PuppetBolt/PuppetBolt.psd1
+++ b/resources/files/windows/PuppetBolt/PuppetBolt.psd1
@@ -5,7 +5,7 @@
     Author            = "Puppet, Inc"
     CompanyName       = "Puppet, Inc"
     Copyright         = '(c) 2017 Puppet, Inc. All rights reserved'
-    FunctionsToExport = @('bolt')
+    FunctionsToExport = @('bolt', 'bolt-inventory-pdb')
     CmdletsToExport   = @()
     VariablesToExport = @()
     AliasesToExport   = @()

--- a/resources/files/windows/PuppetBolt/PuppetBolt.psm1
+++ b/resources/files/windows/PuppetBolt/PuppetBolt.psm1
@@ -12,4 +12,9 @@ function bolt {
     &$env:RUBY_DIR\bin\ruby -S -- $env:RUBY_DIR\bin\bolt ($args -replace '"', '"""')
 }
 
+function bolt-inventory-pdb {
+    &$env:RUBY_DIR\bin\ruby -S -- $env:RUBY_DIR\bin\bolt-inventory-pdb ($args -replace '"', '"""')
+}
+
 Export-ModuleMember -Function bolt -Variable *
+Export-ModuleMember -Function bolt-inventory-pdb -Variable *


### PR DESCRIPTION
Closes puppetlabs/bolt#1172

This adds a wrapper script for the `bolt-inventory-pdb` command similar
to the one we use for `bolt`. The script gets installed to
`/opt/puppetlabs/bin` and symlinked from `/usr/local/bin` which is
typically on the users path. This then calls the actual ruby script at
`/opt/puppetlabs/bolt/bin` to execute the bolt-inventory-pdb command.
This is currently only availbable for linux and osx platforms