### PR TITLE
(maint) Fix curl install on ubuntu 1804

### DIFF
--- a/configs/platforms/ubuntu-18.04-amd64.rb
+++ b/configs/platforms/ubuntu-18.04-amd64.rb
@@ -4,9 +4,10 @@ platform "ubuntu-18.04-amd64" do |plat|
   plat.servicetype "systemd"
   plat.codename "bionic"
 
+  plat.provision_with "export DEBIAN_FRONTEND=noninteractive"
   plat.provision_with "curl https://enterprise.delivery.puppetlabs.net/pluto.pub.gpg | apt-key add - "
   plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-#{plat.get_codename}.deb"
-  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper rsync fakeroot git"
-  plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
+  plat.provision_with "apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper rsync fakeroot git"
+  plat.install_build_dependencies_with "apt-get install -qy --no-install-recommends "
   plat.vmpooler_template "ubuntu-1804-x86_64"
 end


### PR DESCRIPTION
Because of the install command from https://github.com/puppetlabs/vanagon/blob/master/lib/vanagon/platform/deb.rb#L102 and a new version of curl we end up with an interctive message:

```
There are services installed on your system which need to be restarted when
certain libraries, such as libpam, libc, and libssl, are upgraded. Since these
restarts may cause interruptions of service for the system, you will normally be
prompted on each upgrade for the list of services you wish to restart.  You can
choose this option to avoid being prompted; instead, all necessary restarts will
be done for you automatically so you can avoid being asked questions on each
library upgrade.

Restart services during package upgrades without asking? [yes/no]
```
This commits adds `DEBIAN_FRONTEND=noninteractive` before any other install commands are
run on the VM, to unblock the building of bolt until a new version of vanagon is released.

PORTED FROM: https://github.com/puppetlabs/puppet-agent/pull/1789