### PR TITLE
(packaging) Update base image for puppet-bolt docker image to bionic

### DIFF
--- a/docker/puppet-bolt/Dockerfile
+++ b/docker/puppet-bolt/Dockerfile
@@ -1,11 +1,11 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 ARG version="1.24.0"
 ARG vcs_ref
 ARG build_date
 
 ENV BOLT_VERSION="$version"
-ENV UBUNTU_CODENAME="xenial"
+ENV UBUNTU_CODENAME="bionic"
 ENV BOLT_DISABLE_ANALYTICS="true"
 
 LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \


### PR DESCRIPTION
This commit updates the base image for the puppet-bolt container to ubuntu 1804. This change follows the rest of the dockerized puppet projects (most notably the puppet-agent container which this image is modeled after). https://github.com/puppetlabs/puppet-agent/commit/382446021b23712191723161e90da5d61f5955e7