### PR TITLE
(packaging) Set Docker container locale to UTF-8

### DIFF
--- a/docker/puppet-bolt/Dockerfile
+++ b/docker/puppet-bolt/Dockerfile
@@ -7,6 +7,7 @@ ARG build_date
 ENV BOLT_VERSION="$version"
 ENV UBUNTU_CODENAME="bionic"
 ENV BOLT_DISABLE_ANALYTICS="true"
+ENV LANG="C.UTF-8"
 
 LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
       org.label-schema.vendor="Puppet" \

--- a/docker/puppet-bolt/spec/dockerfile_spec.rb
+++ b/docker/puppet-bolt/spec/dockerfile_spec.rb
@@ -31,4 +31,10 @@ describe 'puppet-bolt container' do
     expect(result[:stdout]).to match(/root/)
     expect(result[:stdout]).to match(/Analytics opt-out is set, analytics will be disabled/)
   end
+
+  it 'should support logging UTF-8 characters' do
+    result = run_command("docker run -i #{@image} command run 'echo Hello! 😆' -t localhost --debug 2>&1")
+    expect(result[:stdout]).to match(/Hello! 😆/)
+    expect(result[:stdout]).to match(/Successful on 1 node/)
+  end
 end


### PR DESCRIPTION
In some cases, the remote side of a Bolt run will render UTF-8 characters (for example, in `apply_prep`). Bolt's logging mechanism uses the the system locale, which defaults to POSIX, and will throw an exception if it encounters UTF-8. This change sets the locale of our container to UTF-8 globally, which remedies the problem.