### PR TITLE
(GH-1402) Set SSL env variables before running Bolt in PowerShell module

### DIFF
--- a/resources/files/windows/PuppetBolt/PuppetBolt.psm1
+++ b/resources/files/windows/PuppetBolt/PuppetBolt.psm1
@@ -1,19 +1,24 @@
 $fso = New-Object -ComObject Scripting.FileSystemObject
 
-$env:BOLT_BASEDIR = (Get-ItemProperty -Path "HKLM:\Software\Puppet Labs\Bolt").RememberedInstallDir
+$script:BOLT_BASEDIR = (Get-ItemProperty -Path "HKLM:\Software\Puppet Labs\Bolt").RememberedInstallDir
 # Windows API GetShortPathName requires inline C#, so use COM instead
-$env:BOLT_BASEDIR = $fso.GetFolder($env:BOLT_BASEDIR).ShortPath
-$env:RUBY_DIR = $env:BOLT_BASEDIR
-# Set SSL variables to ensure trusted locations are used
-$env:SSL_CERT_FILE = "$($env:BOLT_BASEDIR)\ssl\cert.pem"
-$env:SSL_CERT_DIR = "$($env:BOLT_BASEDIR)\ssl\certs"
+$script:BOLT_BASEDIR = $fso.GetFolder($env:BOLT_BASEDIR).ShortPath
+$script:RUBY_DIR = $script:BOLT_BASEDIR
 
 function bolt {
-    &$env:RUBY_DIR\bin\ruby -S -- $env:RUBY_DIR\bin\bolt ($args -replace '"', '"""')
+    # Set SSL variables to ensure trusted locations are used
+    $env:SSL_CERT_FILE = "$($script:BOLT_BASEDIR)\ssl\cert.pem"
+    $env:SSL_CERT_DIR = "$($script:BOLT_BASEDIR)\ssl\certs"
+
+    &$script:RUBY_DIR\bin\ruby -S -- $script:RUBY_DIR\bin\bolt ($args -replace '"', '"""')
 }
 
 function bolt-inventory-pdb {
-    &$env:RUBY_DIR\bin\ruby -S -- $env:RUBY_DIR\bin\bolt-inventory-pdb ($args -replace '"', '"""')
+    # Set SSL variables to ensure trusted locations are used
+    $env:SSL_CERT_FILE = "$($script:BOLT_BASEDIR)\ssl\cert.pem"
+    $env:SSL_CERT_DIR = "$($script:BOLT_BASEDIR)\ssl\certs"
+
+    &$script:RUBY_DIR\bin\ruby -S -- $script:RUBY_DIR\bin\bolt-inventory-pdb ($args -replace '"', '"""')
 }
 
 Export-ModuleMember -Function bolt -Variable *

--- a/resources/files/windows/PuppetBolt/PuppetBolt.psm1
+++ b/resources/files/windows/PuppetBolt/PuppetBolt.psm1
@@ -2,7 +2,7 @@ $fso = New-Object -ComObject Scripting.FileSystemObject
 
 $script:BOLT_BASEDIR = (Get-ItemProperty -Path "HKLM:\Software\Puppet Labs\Bolt").RememberedInstallDir
 # Windows API GetShortPathName requires inline C#, so use COM instead
-$script:BOLT_BASEDIR = $fso.GetFolder($env:BOLT_BASEDIR).ShortPath
+$script:BOLT_BASEDIR = $fso.GetFolder($script:BOLT_BASEDIR).ShortPath
 $script:RUBY_DIR = $script:BOLT_BASEDIR
 
 function bolt {


### PR DESCRIPTION
This updates the Bolt PowerShell module to use scoped variables instead
of environment variables and set SSL-based environment variables prior
to each invocation of Bolt.

Previously, environment variables were used and the SSL-based variables were set only once, causing issues when running Bolt and PDK in succession.

Fixes puppetlabs/bolt#1402