### PR TITLE
(maint) Remove bolt-inventory-pdb wrapper script

### DIFF
--- a/configs/components/bolt.rb
+++ b/configs/components/bolt.rb
@@ -27,18 +27,14 @@ component "bolt" do |pkg, settings, platform|
     pkg.install_file "../PuppetBolt.psm1", "#{settings[:datadir]}/PowerShell/Modules/PuppetBolt/PuppetBolt.psm1"
   else
     pkg.add_source("file://resources/files/posix/bolt_env_wrapper", sum: "644f069f275f44af277b20a2d0d279c6")
-    pkg.add_source("file://resources/files/posix/bolt_inventory_pdb_wrapper", sum: "5473e5169ed05c8e63ef3e520b3b8c65")
     bolt_exe = File.join(settings[:link_bindir], 'bolt')
-    bolt_inventory_pdb_exe = File.join(settings[:link_bindir], 'bolt-inventory-pdb')
     pkg.install_file "../bolt_env_wrapper", bolt_exe, mode: "0755"
-    pkg.install_file "../bolt_inventory_pdb_wrapper", bolt_inventory_pdb_exe, mode: "0755"
 
     if platform.is_macos?
       pkg.add_source 'file://resources/files/paths.d/50-bolt', sum: '4abf75aebbbfbbefc4fe0173c57ed0b2'
       pkg.install_file('../50-bolt', '/etc/paths.d/50-bolt')
     else
       pkg.link bolt_exe, File.join(settings[:main_bin], 'bolt')
-      pkg.link bolt_inventory_pdb_exe, File.join(settings[:main_bin], 'bolt-inventory-pdb')
     end
   end
 end

--- a/resources/files/posix/bolt_inventory_pdb_wrapper
+++ b/resources/files/posix/bolt_inventory_pdb_wrapper
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-# avoid influences from already pre-configured other ruby environments
-env -u GEM_HOME -u GEM_PATH -u DLN_LIBRARY_PATH -u RUBYLIB -u RUBYLIB_PREFIX -u RUBYOPT -u RUBYPATH -u RUBYSHELL -u LD_LIBRARY_PATH -u LD_PRELOAD SHELL=/bin/sh /opt/puppetlabs/bolt/bin/bolt-inventory-pdb "$@"

--- a/resources/files/windows/PuppetBolt/PuppetBolt.psd1
+++ b/resources/files/windows/PuppetBolt/PuppetBolt.psd1
@@ -5,7 +5,7 @@
     Author            = "Puppet, Inc"
     CompanyName       = "Puppet, Inc"
     Copyright         = '(c) 2017 Puppet, Inc. All rights reserved'
-    FunctionsToExport = @('bolt', 'bolt-inventory-pdb')
+    FunctionsToExport = @('bolt')
     CmdletsToExport   = @()
     VariablesToExport = @()
     AliasesToExport   = @()

--- a/resources/files/windows/PuppetBolt/PuppetBolt.psm1
+++ b/resources/files/windows/PuppetBolt/PuppetBolt.psm1
@@ -13,13 +13,4 @@ function bolt {
     &$script:RUBY_DIR\bin\ruby -S -- $script:RUBY_DIR\bin\bolt ($args -replace '"', '"""')
 }
 
-function bolt-inventory-pdb {
-    # Set SSL variables to ensure trusted locations are used
-    $env:SSL_CERT_FILE = "$($script:BOLT_BASEDIR)\ssl\cert.pem"
-    $env:SSL_CERT_DIR = "$($script:BOLT_BASEDIR)\ssl\certs"
-
-    &$script:RUBY_DIR\bin\ruby -S -- $script:RUBY_DIR\bin\bolt-inventory-pdb ($args -replace '"', '"""')
-}
-
 Export-ModuleMember -Function bolt -Variable *
-Export-ModuleMember -Function bolt-inventory-pdb -Variable *


### PR DESCRIPTION
The `bolt-inventory-pdb` command was removed in Bolt 2.0, so it no
longer is packaged with Bolt. This removes a wrapper script for
executing the command.