### PR TITLE
(packaging) Build Ubuntu 20.04 puppet-bolt packages

### DIFF
--- a/configs/platforms/ubuntu-20.04-amd64.rb
+++ b/configs/platforms/ubuntu-20.04-amd64.rb
@@ -1,0 +1,12 @@
+platform "ubuntu-20.04-amd64" do |plat|
+  plat.servicedir "/lib/systemd/system"
+  plat.defaultdir "/etc/default"
+  plat.servicetype "systemd"
+  plat.codename "focal"
+
+  plat.provision_with "curl https://enterprise.delivery.puppetlabs.net/pluto.pub.gpg | apt-key add - "
+  plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-#{plat.get_codename}.deb"
+  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper rsync fakeroot git"
+  plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
+  plat.vmpooler_template "ubuntu-2004-x86_64"
+end


### PR DESCRIPTION
Part of puppetlabs/bolt#1782

Blocked by puppetlabs/puppet-runtime#335