### PR TITLE
(maint) Fix Powershell module export statement

### DIFF
--- a/resources/files/windows/PuppetBolt/PuppetBolt.psd1
+++ b/resources/files/windows/PuppetBolt/PuppetBolt.psd1
@@ -5,7 +5,6 @@
     Author            = "Puppet, Inc"
     CompanyName       = "Puppet, Inc"
     Copyright         = '(c) 2017 Puppet, Inc. All rights reserved'
-    FunctionsToExport = @('bolt')
     CmdletsToExport   = @()
     VariablesToExport = @()
     AliasesToExport   = @()


### PR DESCRIPTION
Removes `FunctionsToExport` from the PowerShell module manifest file which allows the `Export-ModuleMember` statement inside the `pms1` module file to control what cmdlets are public.
