### PR TITLE
(maint) Add Powershell Module Manifest Template

### DIFF
--- a/configs/components/bolt.rb
+++ b/configs/components/bolt.rb
@@ -19,12 +19,11 @@ component "bolt" do |pkg, settings, platform|
 
   if platform.is_windows?
     pkg.install { ["#{settings[:ruby_bindir]}/rake.bat -f pwsh_module/Rakefile pwsh:generate_module"] }
-    # PowerShell Module
-    pkg.add_source("file://resources/files/windows/PuppetBolt/PuppetBolt.psd1", sum: "f21e2bcfcb64da273e561e6066dce949")
 
+    # PowerShell Module
     pkg.directory "#{settings[:datadir]}/PowerShell/Modules/PuppetBolt"
-    pkg.install_file "pwsh_module/pwsh_bolt.psm1", "#{settings[:datadir]}/PowerShell/Modules/PuppetBolt/PuppetBolt.psm1"
-    pkg.install_file "../PuppetBolt.psd1", "#{settings[:datadir]}/PowerShell/Modules/PuppetBolt/PuppetBolt.psd1"
+    pkg.install_file "pwsh_module/PuppetBolt.psm1", "#{settings[:datadir]}/PowerShell/Modules/PuppetBolt/PuppetBolt.psm1"
+    pkg.install_file "pwsh_module/PuppetBolt.psd1", "#{settings[:datadir]}/PowerShell/Modules/PuppetBolt/PuppetBolt.psd1"
   else
     pkg.add_source("file://resources/files/posix/bolt_env_wrapper", sum: "644f069f275f44af277b20a2d0d279c6")
     bolt_exe = File.join(settings[:link_bindir], 'bolt')

--- a/configs/projects/puppet-bolt.rb
+++ b/configs/projects/puppet-bolt.rb
@@ -42,6 +42,7 @@ project "puppet-bolt" do |proj|
 
     module_directory = File.join(proj.datadir.sub(/^.*:\//, ''), 'PowerShell', 'Modules')
     proj.extra_file_to_sign File.join(module_directory, 'PuppetBolt', 'PuppetBolt.psm1')
+    proj.extra_file_to_sign File.join(module_directory, 'PuppetBolt', 'PuppetBolt.psd1')
     proj.signing_hostname 'windowssigning-aio1-prod.delivery.puppetlabs.net'
     proj.signing_username 'Administrator'
     proj.signing_command 'pwsh.exe -File pwsh7.ps1 -FilePath'


### PR DESCRIPTION
Adds the `PuppetBolt.psd1` manifest file that is built along with the `PuppetBolt.psm1` module file. This completes managing the PowerShell module creation process.
