### PR TITLE
(GH-1998) Update powershell generation to work with new Rakelib

### DIFF
--- a/configs/components/bolt.rb
+++ b/configs/components/bolt.rb
@@ -18,7 +18,7 @@ component "bolt" do |pkg, settings, platform|
   end
 
   if platform.is_windows?
-    pkg.install { ["#{settings[:ruby_bindir]}/rake.bat -f pwsh_module/Rakefile pwsh:generate_module"] }
+    pkg.install { ["#{settings[:ruby_bindir]}/rake.bat pwsh:generate_module"] }
 
     # PowerShell Module
     pkg.directory "#{settings[:datadir]}/PowerShell/Modules/PuppetBolt"


### PR DESCRIPTION
[This update to Bolt](https://github.com/puppetlabs/bolt/pull/2011)
moves all Rake tasks to the `rakelib` directory, which rake
automatically loads. This includes moving the rake tasks used to
generate the Powershell module from `pwsh_module` to the new directory
where they are automatically loaded by Rake. This updates the command in
Bolt's component build to generate the Powershell module to load the
task from the new location by not specifying a file to load tasks from.