### PR TITLE
(GH-2078) Add topic guides to PowerShell module

### DIFF
--- a/configs/components/bolt.rb
+++ b/configs/components/bolt.rb
@@ -24,6 +24,10 @@ component "bolt" do |pkg, settings, platform|
     pkg.directory "#{settings[:datadir]}/PowerShell/Modules/PuppetBolt"
     pkg.install_file "pwsh_module/PuppetBolt.psm1", "#{settings[:datadir]}/PowerShell/Modules/PuppetBolt/PuppetBolt.psm1"
     pkg.install_file "pwsh_module/PuppetBolt.psd1", "#{settings[:datadir]}/PowerShell/Modules/PuppetBolt/PuppetBolt.psd1"
+
+    # Add topic guides to the PowerShell Module
+    pkg.directory "#{settings[:datadir]}/PowerShell/Modules/PuppetBolt/en-US"
+    pkg.install { ["/usr/bin/cp pwsh_module/en-US/* #{settings[:datadir]}/PowerShell/Modules/PuppetBolt/en-US"] }
   else
     pkg.add_source("file://resources/files/posix/bolt_env_wrapper", sum: "644f069f275f44af277b20a2d0d279c6")
     bolt_exe = File.join(settings[:link_bindir], 'bolt')

--- a/resources/windows/wix/directorylist.wxs.erb
+++ b/resources/windows/wix/directorylist.wxs.erb
@@ -11,7 +11,9 @@
 
         <Directory Id="PowerShellDir" Name="WindowsPowerShell">
           <Directory Id="PowerShellModuleDir" Name="Modules">
-            <Directory Id="PowerShellBoltModuleDir" Name="PuppetBolt" />
+            <Directory Id="PowerShellBoltModuleDir" Name="PuppetBolt">
+              <Directory Id="PowerShellBoltModuleHelpDir" Name="en-US" />
+            </Directory>
           </Directory>
         </Directory>
       </Directory>

--- a/resources/windows/wix/powershell.wxs.erb
+++ b/resources/windows/wix/powershell.wxs.erb
@@ -22,6 +22,26 @@
           Source="$(var.AppSourcePath)\share\PowerShell\Modules\PuppetBolt\PuppetBolt.psm1"
           KeyPath="yes" />
       </Component>
+
+      <Component
+        Id="about_bolt_inventory.help.txt"
+        Directory="PowerShellBoltModuleHelpDir"
+        Guid="90b31dd1-28ef-4276-b672-8e87d432f70f">
+        <File
+          Id="about_bolt_inventory.help.txt"
+          Source="$(var.AppSourcePath)\share\PowerShell\Modules\PuppetBolt\en-US\about_bolt_inventory.help.txt"
+          KeyPath="yes" />
+      </Component>
+
+      <Component
+        Id="about_bolt_project.help.txt"
+        Directory="PowerShellBoltModuleHelpDir"
+        Guid="11b6aacc-a4de-4cc6-90e1-cc61ebb4696c">
+        <File
+          Id="about_bolt_project.help.txt"
+          Source="$(var.AppSourcePath)\share\PowerShell\Modules\PuppetBolt\en-US\about_bolt_project.help.txt"
+          KeyPath="yes" />
+      </Component>
     </ComponentGroup>
   </Fragment>
 </Wix>


### PR DESCRIPTION
This adds Bolt's [topic
guides](https://github.com/puppetlabs/bolt/pull/2088) to the PowerShell
module. It updates the Bolt component to copy the renamed topic guides
from `pwsh_module/en-US` in the Bolt repo to the PowerShell module
directory. It also updates a couple of WiX files to create a directory
in the PowerShell module for the help pages and adds each of the help
pages as a component.

Part of puppetlabs/bolt#2078