### PR TITLE
Use Tarball method for MSI based packages

### DIFF
--- a/configs/components/bolt-create-ruby-tarballs.rb
+++ b/configs/components/bolt-create-ruby-tarballs.rb
@@ -1,0 +1,34 @@
+component "bolt-create-ruby-tarballs" do |pkg, settings, platform|
+  # We only create the tarballs on Windows right now
+  if platform.is_windows?
+    pkg.add_source("file://resources/files/install-tarballs/extract_all.rb")
+    pkg.add_source("file://resources/files/install-tarballs/remove_all.rb")
+    pkg.directory "#{settings[:datadir]}/install-tarballs"
+    # Unlike other examples, where the path would be '../<file>' we use the current workding directory.  This is because
+    # even though we add a source as above, because it is not a gem or tar etc., the component has nothing to extract therefore
+    # we don't end up in a component directory
+    pkg.install_file "extract_all.rb", "#{settings[:datadir]}/install-tarballs/extract_all.rb"
+    pkg.install_file "remove_all.rb", "#{settings[:datadir]}/install-tarballs/remove_all.rb"
+
+    pkg.build do
+      build_commands = []
+
+      # Create the destination directory incase it doesn't exist already
+      build_commands << "mkdir -p #{settings[:datadir]}/install-tarballs"
+      build_commands << "pushd #{settings[:prefix]}"
+
+      # Tar up the base ruby. This will exclude the ruby runtime as we need that for the extraction
+      dirs = [
+        "lib/ruby/gems",
+      ]
+      build_commands << "#{platform.tar} --create --gzip --file share/install-tarballs/ruby-#{settings[:ruby_version]}.tgz --directory=. " + dirs.join(" ")
+
+      # We delete the source directories AFTER tarring to make debugging easier if something goes wrong.
+      dirs.each { |dir| build_commands << "rm -rf #{dir}"}
+
+      build_commands << "popd"
+
+      build_commands
+    end
+  end
+end

--- a/configs/projects/puppet-bolt.rb
+++ b/configs/projects/puppet-bolt.rb
@@ -53,6 +53,7 @@ project "puppet-bolt" do |proj|
 
   proj.component "bolt-runtime"
   proj.component "bolt"
+  proj.component "bolt-create-ruby-tarballs"
 
   proj.directory proj.prefix
   proj.directory proj.link_bindir

--- a/resources/files/install-tarballs/extract_all.rb
+++ b/resources/files/install-tarballs/extract_all.rb
@@ -1,0 +1,70 @@
+# Idea from https://stackoverflow.com/questions/856891/unzip-zip-tar-tag-gz-files-with-ruby
+# Altered using https://github.com/puppetlabs/puppet/blob/983154f7e29a2a50d416d889a6fed012b9b12399/lib/puppet/module_tool/tar/mini.rb
+#
+# WARNING - This extraction blindly assumes the tarballs are sane and correct. Unlike the `.../module_tool/tar/mini.rb` implementation, this
+# script does not do any checks:
+# - Symlinks within the tar will throw an error
+# - We assume that all files in the tar have relative paths. If there is an absolute path in the tarball it will 'escape' the intended extract directory
+# - Avoids extra disk IO (e.g. expand_path) as the tarballs will have 30,000+ files inside
+
+require 'fileutils'
+require 'rubygems/package'
+require 'zlib'
+
+TAR_LONGLINK = '././@LongLink'
+
+def logmessage(message)
+  puts message if ENV['BOLT_DEBUG']
+end
+
+# From lib/puppet/module_tool/tar/mini.rb
+EXECUTABLE = 0755
+NOT_EXECUTABLE = 0644
+USER_EXECUTE = 0100
+
+def sanitized_mode(old_mode)
+  # From lib/puppet/module_tool/tar/mini.rb
+  old_mode & USER_EXECUTE != 0 ? EXECUTABLE : NOT_EXECUTABLE
+end
+
+def unpack(sourcefile, destdir, _)
+  Gem::Package::TarReader.new( Zlib::GzipReader.open sourcefile ) do |tar|
+    dest = nil
+    tar.each do |entry|
+      if entry.full_name == TAR_LONGLINK
+        dest = File.join destdir, entry.read.strip
+        next
+      end
+      dest ||= File.join(destdir, entry.full_name)
+      if entry.directory? || (entry.header.typeflag == '' && entry.full_name.end_with?('/'))
+        # Due to the size of the tarballs, logging consumes a ton of time. Just ignore it for now
+        # logmessage("dir #{dest}")
+        File.delete dest if File.file? dest
+        # set_dir_mode! from mini.rb will always set this to EXECUTABLE so just use that - ref
+        FileUtils.mkdir_p dest, :mode => EXECUTABLE, :verbose => false
+      elsif entry.file? || (entry.header.typeflag == '' && !entry.full_name.end_with?('/'))
+        # Due to the size of the tarballs, logging consumes a ton of time. Just ignore it for now
+        # logmessage "file #{dest}"
+        FileUtils.rm_rf dest if File.directory? dest
+        File.open dest, "wb" do |f|
+          f.print entry.read
+        end
+        FileUtils.chmod sanitized_mode(entry.header.mode), dest, :verbose => false
+      # There should be NO symlinks on our tarballs so just ignore them
+      # elsif entry.header.typeflag == '2' #Symlink!
+      #   File.symlink entry.header.linkname, dest
+      else
+        logmessage("Unkown tar entry: #{entry.full_name} type: #{entry.header.typeflag}.")
+      end
+      dest = nil
+    end
+  end
+end
+
+script_dir = __dir__
+dest_dir = File.expand_path(File.join(script_dir, '..', '..'))
+
+Dir.glob(File.join(script_dir, '*.tgz')) do |targz_filename|
+  logmessage("Extracting #{targz_filename} to #{dest_dir} ...")
+  unpack(targz_filename, dest_dir, nil)
+end

--- a/resources/files/install-tarballs/remove_all.rb
+++ b/resources/files/install-tarballs/remove_all.rb
@@ -1,0 +1,25 @@
+require 'pathname'
+require 'fileutils'
+
+script_dir = __dir__
+install_dir = File.expand_path(File.join(script_dir, '..', '..'))
+
+def logmessage(message)
+  puts message
+end
+
+def ruby_api_version(ruby_version)
+  gem_ver = Gem::Version.new(ruby_version)
+  gem_ver.segments[0..1].join('.') + '.0'
+end
+
+# Remove the ruby and puppet cache, but not the actual runtime for the ruby we're _actually_ using
+# right now. We need that!
+dirs_to_delete = ["lib/ruby/gems"]
+
+dirs_to_delete.each { |dir| logmessage("'#{dir}' is scheduled for deletion") }
+dirs_to_delete.each do |dir|
+  absolute_dir = File.join(install_dir, dir)
+  logmessage("Attempting to delete '#{absolute_dir}'...")
+  FileUtils.rm_rf(absolute_dir)
+end

--- a/resources/windows/wix/customactions.wxs.erb
+++ b/resources/windows/wix/customactions.wxs.erb
@@ -20,5 +20,32 @@
       Property="INSTALLDIR"
       Value="[CMDLINE_INSTALLDIR]"
       Execute="firstSequence" />
+
+    <!-- INSTALLDIR is not available for Deferred Custom Actions.  So we need to save it for later user -->
+    <CustomAction
+      Id="SetPropertyForExtractTarballs"
+      Property="ExtractTarballs"
+      Value="[INSTALLDIR]" />
+    <Binary Id='TarballScript' SourceFile='..\tarball.vbs' />
+    <CustomAction
+      Id="ExtractTarballs"
+      BinaryKey="TarballScript"
+      VBScriptCall="ExtractTarballs"
+      Execute="deferred"
+      Return="check"
+      Impersonate="no" />
+
+    <!-- INSTALLDIR is not available for Deferred Custom Actions.  So we need to save it for later user -->
+    <CustomAction
+      Id="SetPropertyForRemoveTarballs"
+      Property="RemoveTarballs"
+      Value="[INSTALLDIR]" />
+    <CustomAction
+      Id="RemoveTarballs"
+      BinaryKey="TarballScript"
+      VBScriptCall="RemoveTarballs"
+      Execute="deferred"
+      Return="check"
+      Impersonate="no" />
   </Fragment>
 </Wix>

--- a/resources/windows/wix/sequences.wxs.erb
+++ b/resources/windows/wix/sequences.wxs.erb
@@ -21,6 +21,12 @@
       <Custom Action='SetFromCmdLineInstallDir' After='AppSearch'>
         CMDLINE_INSTALLDIR
       </Custom>
+      <!-- Tarball Extractor on install -->
+      <Custom Action="SetPropertyForExtractTarballs" Before="InstallInitialize">NOT REMOVE</Custom>
+      <Custom Action='ExtractTarballs' After='InstallFiles'>NOT REMOVE</Custom>
+      <!-- Tarball Remover on uninstall -->
+      <Custom Action="SetPropertyForRemoveTarballs" Before="InstallInitialize">REMOVE~="ALL" OR MaintenanceMode="Remove"</Custom>
+      <Custom Action='RemoveTarballs' Before='RemoveFiles'>REMOVE~="ALL" OR MaintenanceMode="Remove"</Custom>
     </InstallExecuteSequence>
 
     <SetProperty Id="ARPINSTALLLOCATION" Value="[INSTALLDIR]" After="CostFinalize" />

--- a/resources/windows/wix/tarball.vbs
+++ b/resources/windows/wix/tarball.vbs
@@ -1,0 +1,161 @@
+On Error Resume Next
+
+' This VBScript file is imported into the Binary table
+
+' Example INSTALLDIR property. Its value is 'C:\Program Files\Puppet Labs\Bolt\'.
+' As this is deferred, use the CustomActionData property instead
+Dim InstallDir : InstallDir = Session.Property("CustomActionData")
+
+' https://docs.microsoft.com/en-us/windows/desktop/msi/session-message
+Const msiMessageTypeError   = &H01000000
+Const msiMessageTypeWarning = &H02000000
+Const msiMessageTypeInfo    = &H04000000
+
+' https://docs.microsoft.com/en-us/windows/desktop/msi/return-values-of-jscript-and-vbscript-custom-actions
+Const IDOK = 1
+Const IDABORT = 3
+
+Dim wshShell : Set wshShell = CreateObject("WScript.Shell")
+Dim fso : Set fso = CreateObject("Scripting.FileSystemObject")
+Dim comspec : comspec = wshShell.ExpandEnvironmentStrings("%comspec%")
+
+Sub Log (Message, IsError)
+  ' Logs through cscript
+  If IsObject(WScript) Then
+    If IsObject(WScript.StdErr) And IsError = True Then
+      WScript.StdErr.WriteLine(Message)
+    ElseIf IsObject(WScript.StdOut) Then
+      WScript.StdOut.WriteLine(Message)
+    End If
+  End If
+  ' Logs through MSI
+  If IsObject(Session) Then
+    ' https://docs.microsoft.com/en-us/windows/desktop/msi/installer-createrecord
+    Dim logRecord : Set logRecord = Installer.CreateRecord(1) ' 1 entry
+    logRecord.StringData(1) = Message ' Set Index 1
+    Dim kind : kind = msiMessageTypeInfo
+    If IsError = True Then kind = msiMessageTypeError
+    Session.Message kind, logRecord
+  End If
+End Sub
+
+' Executes command, sending its stdout / stderr to the WScript host
+Function ExecuteCommand(Command)
+  Dim output: output = ""
+  Log "Executing Command : " & Command, False
+
+  Dim tempFilePath : tempFilePath = wshShell.ExpandEnvironmentStrings("%TEMP%\" + fso.GetTempName())
+  Dim tempBatFile : tempBatFile = wshShell.ExpandEnvironmentStrings("%TEMP%\" + fso.GetTempName() + ".bat")
+  ' Open the temp .bat file for writing
+  ' Unfortunately due to the strange double quoting behaviour in wshShell.Run we create a temporary
+  ' Batch file with the command we want, and then call the batch file.  Note that we explicitly call
+  ' EXIT /B so that we avoid the case where someone malicious modifies the BAT file while being run.
+  ' Remember that cmd.exe reads and executes BAT files line-by-line. The EXIT statement tells cmd
+  ' to exit even if there's malicious code following.
+  Dim outFile : Set outFile = fso.OpenTextFile(tempBatFile, 2, true)
+  outFile.WriteLine(Command & " > """ & tempFilePath & """ 2>&1 && EXIT /B %ERRORLEVEL%")
+  outFile.Close()
+  Set outFile = Nothing
+  ' https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/d5fk67ky%28v%3dvs.84%29
+  ' intWindows Style - 0 - Hides the window and activates another window.
+  ' bWaitOnReturn - True - waits for program termination
+  Dim exitCode : exitCode = wshShell.Run(comspec & " /c CALL " & tempBatFile & " 2>&1", 0, True)
+  fso.DeleteFile(tempBatFile)
+  If fso.FileExists(tempFilePath) Then
+    Set outFile = fso.OpenTextFile(tempFilePath)
+    Log "--- Output", false
+    Do While Not outFile.AtEndOfStream
+    Log outFile.ReadLine(), false
+    Loop
+    outFile.Close()
+    Log "---", false
+    fso.DeleteFile(tempFilePath)
+  End If
+
+  If exitCode <> 0 Then
+    Log "Execution Failed With Code: " & exitCode, True
+    ExecuteCommand = False
+  else
+    ExecuteCommand = True
+  End If
+End Function
+
+Function GetRubyDirectory(RootDirectory)
+  GetRubyDirectory = ""
+  ' Find a ruby environment with the PDK gem
+  Dim RubyFolder : Set RubyFolder = fso.GetFolder(RootDirectory)
+  For Each RubyVerSubfolder in RubyFolder.SubFolders
+    Dim RubyFullVersion : RubyFullVersion = RubyVerSubfolder.Name
+    Dim arrRubyVersion : arrRubyVersion = Split(RubyFullVersion, ".")
+    Dim RubyMinorVersion : RubyMinorVersion = arrRubyVersion(0) + "." + arrRubyVersion(1) + ".0"
+    Dim GemFolderPath : GemFolderPath = RubyVerSubfolder.Path + "\lib\ruby\gems\" + RubyMinorVersion + "\gems"
+
+    if fso.FolderExists(GemFolderPath) Then
+      Dim FoundPDK : FoundPDK = false
+      For Each GemFolder in fso.GetFolder(GemFolderPath).SubFolders
+        FoundPDK = FoundPDK OR Left(GemFolder.Name,4) = "pdk-"
+      Next
+      If FoundPDK Then
+        GetRubyDirectory = RubyFullVersion
+      End If
+    End If
+  Next
+End Function
+
+' Mainline
+Function RunRubyScriptFile(ScriptFileName)
+  Log "InstallDir is " + InstallDir, false
+
+  ' Based on equivalent PowerShell script at;
+  ' https://github.com/puppetlabs/pdk-vanagon/blob/07a4ee7c29ba630ffbec6d87388688b6de90fbfd/resources/files/windows/PuppetDevelopmentKit/PuppetDevelopmentKit.psm1
+  Dim BOLT_BASEDIR
+  Dim RUBY_DIR
+  Dim SSL_CERT_FILE
+  Dim SSL_CERT_DIR
+
+  BOLT_BASEDIR = fso.GetFolder(InstallDir).ShortPath
+
+  Log "BOLT_BASEDIR is " + BOLT_BASEDIR, false
+  RUBY_DIR = BOLT_BASEDIR + "\lib\ruby\"
+  SSL_CERT_FILE = BOLT_BASEDIR + "\ssl\cert.pem"
+  SSL_CERT_DIR = BOLT_BASEDIR + "\ssl\certs"
+
+  Log "BOLT_BASEDIR is " + BOLT_BASEDIR, false
+  Log "RUBY_DIR is " + RUBY_DIR, false
+  Log "SSL_CERT_FILE is " + SSL_CERT_FILE, false
+  Log "SSL_CERT_DIR is " + SSL_CERT_DIR, false
+
+  Dim RubyPath : RubyPath = BOLT_BASEDIR + "\bin\ruby.exe"
+  Dim ProcessEnv : Set ProcessEnv = wshShell.Environment( "PROCESS" )
+
+  Log "Creating process level environment variables...", false
+  ProcessEnv("BOLT_BASEDIR") = BOLT_BASEDIR
+  ProcessEnv("RUBY_DIR") = RUBY_DIR
+  ProcessEnv("SSL_CERT_FILE") = SSL_CERT_FILE
+  ProcessEnv("SSL_CERT_DIR") = SSL_CERT_DIR
+  ProcessEnv("PDK_DEBUG") = "True"
+
+  Dim ExtractScript : ExtractScript = BOLT_BASEDIR + "\share\install-tarballs\" + ScriptFileName
+  If Not(fso.FileExists(ExtractScript)) Then
+    Log "Extract script " & ExtractScript & " could not be found", true
+    RunRubyScriptFile = IDABORT
+    Exit Function
+  End If
+
+  ' Note Returning values back to the MSI Engine only works with Binary type Custom Actions
+  if ExecuteCommand("""" & RubyPath & """ -S -- """ & ExtractScript & """") Then
+    Log "Completed with success", false
+    RunRubyScriptFile = IDOK
+  Else
+    Log "Completed with error", true
+    RunRubyScriptFile = IDABORT
+  End If
+End Function
+
+Function ExtractTarballs()
+  ExtractTarballs = RunRubyScriptFile("extract_all.rb")
+End Function
+
+Function RemoveTarballs()
+  RemoveTarballs = RunRubyScriptFile("remove_all.rb")
+End Function


### PR DESCRIPTION
This PR increases the speed at which Bolt MSI installs complete by using tarballs of the included Ruby gems instead of tracking each file in the MSI table.

- Create tarballs of ruby gems for Windows
- Extract tarballs during MSI Installation
- Remove extracted files on MSI uninstall

Acceptance Criteria:

1. Install MSI built from this PR on a fresh machine without failure. Run example command
1. Install MSI built from this PR on a fresh machine without failure. Then uninstall from machine without failure. All files installed should be removed.
1. Install bolt 2.24.1, then install MSI built from this PR. Product should upgrade without failure. Run example command
1. Install bolt 2.24.1, then install MSI built from this PR, then uninstall. All files installed should be removed without failure.

Example command: `bolt command '$PSVersionTable' -t localhost`

Fixes https://github.com/puppetlabs/bolt/issues/2099 https://github.com/puppetlabs/bolt/issues/1177