### PR TITLE
(maint) Move to bolt.bat

### DIFF
--- a/configs/components/bolt.rb
+++ b/configs/components/bolt.rb
@@ -20,6 +20,9 @@ component "bolt" do |pkg, settings, platform|
   if platform.is_windows?
     pkg.install { ["#{settings[:ruby_bindir]}/rake.bat pwsh:generate_module"] }
 
+    pkg.add_source("file://resources/files/windows/bolt.bat", sum: "60ead805dc78855d4a1a13230c141daa")
+    pkg.install_file "../bolt.bat", "#{settings[:link_bindir]}/bolt.bat"
+
     # PowerShell Module
     pkg.directory "#{settings[:datadir]}/PowerShell/Modules/PuppetBolt"
     pkg.install_file "pwsh_module/PuppetBolt.psm1", "#{settings[:datadir]}/PowerShell/Modules/PuppetBolt/PuppetBolt.psm1"

--- a/configs/projects/puppet-bolt.rb
+++ b/configs/projects/puppet-bolt.rb
@@ -39,6 +39,8 @@ project "puppet-bolt" do |proj|
       :ManualLink => "https://puppet.com/docs/bolt/",
     })
     proj.setting(:LicenseRTF, "wix/license/LICENSE.rtf")
+    proj.setting(:install_root, File.join("C:", proj.base_dir, proj.company_id, proj.product_id))
+    proj.setting(:link_bindir, File.join(proj.install_root, "bin"))
 
     module_directory = File.join(proj.datadir.sub(/^.*:\//, ''), 'PowerShell', 'Modules')
     proj.extra_file_to_sign File.join(module_directory, 'PuppetBolt', 'PuppetBolt.psm1')
@@ -46,10 +48,10 @@ project "puppet-bolt" do |proj|
     proj.signing_hostname 'windowssigning-aio1-prod.delivery.puppetlabs.net'
     proj.signing_username 'Administrator'
     proj.signing_command 'pwsh.exe -File pwsh7.ps1 -FilePath'
+  else
+    proj.setting(:link_bindir, "/opt/puppetlabs/bin")
+    proj.setting(:main_bin, "/usr/local/bin")
   end
-
-  proj.setting(:link_bindir, "/opt/puppetlabs/bin")
-  proj.setting(:main_bin, "/usr/local/bin")
 
   proj.component "bolt-runtime"
   proj.component "bolt"

--- a/resources/files/windows/bolt.bat
+++ b/resources/files/windows/bolt.bat
@@ -1,0 +1,25 @@
+@ECHO OFF
+REM This is the parent directory of the directory containing this script (resolves to :install_root/Bolt)
+SET BOLT_BASEDIR=%~dp0..
+REM Avoid the nasty \..\ littering the paths.
+SET BOLT_BASEDIR=%BOLT_BASEDIR:\bin\..=%
+
+SET BOLT_DIR=%BOLT_BASEDIR%\puppet
+
+REM Add bolt's bindirs to the PATH
+SET PATH=%BOLT_DIR%\bin;%BOLT_BASEDIR%\bin;%PATH%
+
+REM Set the RUBY LOAD_PATH using the RUBYLIB environment variable
+SET RUBYLIB=%BOLT_DIR%\lib;%RUBYLIB%
+
+REM Translate all slashes to / style to avoid issue #11930
+SET RUBYLIB=%RUBYLIB:\=/%
+
+REM Now return to the caller.
+
+REM Set SSL variables to ensure trusted locations are used
+SET SSL_CERT_FILE=%BOLT_DIR%\ssl\cert.pem
+SET SSL_CERT_DIR=%BOLT_DIR%\ssl\certs
+SET OPENSSL_CONF=%BOLT_DIR%\ssl\openssl.cnf
+
+ruby -S -- bolt %*

--- a/resources/windows/wix/componentgroup.wxs.erb
+++ b/resources/windows/wix/componentgroup.wxs.erb
@@ -5,6 +5,8 @@
 
   <Fragment>
     <ComponentGroup Id="MainComponentGroup">
+      <ComponentRef Id="BoltPathEnvVarible" />
+
       <!-- We can add all components by referencing this one thing -->
       <ComponentGroupRef Id="AppComponentGroup" />
       <ComponentGroupRef Id="PowerShellModuleComponentGroup" />

--- a/resources/windows/wix/directorylist.wxs.erb
+++ b/resources/windows/wix/directorylist.wxs.erb
@@ -2,6 +2,15 @@
 <Wix xmlns='http://schemas.microsoft.com/wix/2006/wi' xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
   <Fragment>
     <DirectoryRef Id='TARGETDIR'>
+      <Component Id="BoltPathEnvVarible" Guid="994a482e-2479-4f97-b074-bc630970fc12">
+        <Environment Id="PATH"
+                    Name="PATH"
+                    Value="[INSTALLDIR]bin"
+                    Permanent="no"
+                    Part="last"
+                    Action="set"
+                    System="no" />
+      </Component>
       <Directory Id="<%= settings[:base_dir] %>" >
         <Directory Id="<%= settings[:company_id] %>" Name="<%= settings[:pl_company_name] %>">
           <Directory Id='INSTALLDIR' Name="<%= settings[:product_id] %>">


### PR DESCRIPTION
## Migrate Bolt to `bolt.bat` from a PowerShell function

Creates the files used in https://github.com/puppetlabs/bolt/pull/2532

Closes https://github.com/puppetlabs/bolt/issues/2551


## Acceptance Criteria:

### After building with vanagon, 

1. Install the new MSI
2. Remove the `bolt` function declaration from `C:\Program Files\WindowsPowerShell\Modules\PuppetBolt\PuppetBolt.psm1` (this is removed in https://github.com/puppetlabs/bolt/pull/2532 but won't be pulled in this PR)

### The verify the following:

- `C:\Program Files\Puppet Labs\Bolt\bin\bolt.bat` has the same contents as the file in this PR
- The `PATH` environment variable contains `C:\Program Files\Puppet Labs\Bolt\bin`
- Any shell finds the `bolt` command

> Note: Any problems with argument parsing should be logged in https://github.com/puppetlabs/bolt/pull/2532