### PR TITLE
(RE-13450) Remove gpg_key from local repo

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -3,7 +3,6 @@ project: 'puppet-bolt'
 gem_name: 'bolt'
 build_gem: TRUE
 gpg_name: 'info@puppetlabs.com'
-gpg_key: '7F438280EF8D349F'
 sign_tar: FALSE
 vanagon_project: TRUE
 repo_name: 'puppet-enterprise-tools'


### PR DESCRIPTION
The local gpg_key setting is overridden by the one in build data. The
current setting refers to the soon-to-be-expired key.

This commit removes the gpg_key setting from build_defaults.yaml as an
attempt to reduce confusion.