### PR TITLE
(maint) Use --log-level debug in docker spec tests

### DIFF
--- a/docker/puppet-bolt/spec/dockerfile_spec.rb
+++ b/docker/puppet-bolt/spec/dockerfile_spec.rb
@@ -27,13 +27,13 @@ describe 'puppet-bolt container' do
   end
 
   it 'should run a bolt command and analytics should be disabled' do
-    result = run_command("docker run -i #{@image} command run whoami -t localhost --debug 2>&1")
+    result = run_command("docker run -i #{@image} command run whoami -t localhost --log-level debug 2>&1")
     expect(result[:stdout]).to match(/root/)
     expect(result[:stdout]).to match(/Analytics opt-out is set, analytics will be disabled/)
   end
 
   it 'should support logging UTF-8 characters' do
-    result = run_command("docker run -i #{@image} command run 'echo Hello! 😆' -t localhost --debug 2>&1")
+    result = run_command("docker run -i #{@image} command run 'echo Hello! 😆' -t localhost --log-level debug 2>&1")
     expect(result[:stdout]).to match(/Hello! 😆/)
     expect(result[:stdout]).to match(/Successful on 1 target/)
   end


### PR DESCRIPTION
This updates the docker container spec tests to use the `--log-level
debug` option in Bolt commands instead of the unsupported `--debug`
option.