### PR TITLE
(maint) Fix bolt.bat file environment variables

### DIFF
--- a/resources/files/windows/bolt.bat
+++ b/resources/files/windows/bolt.bat
@@ -4,22 +4,18 @@ SET BOLT_BASEDIR=%~dp0..
 REM Avoid the nasty \..\ littering the paths.
 SET BOLT_BASEDIR=%BOLT_BASEDIR:\bin\..=%
 
-SET BOLT_DIR=%BOLT_BASEDIR%\puppet
-
 REM Add bolt's bindirs to the PATH
-SET PATH=%BOLT_DIR%\bin;%BOLT_BASEDIR%\bin;%PATH%
+SET PATH=%BOLT_BASEDIR%\bin;%PATH%
 
 REM Set the RUBY LOAD_PATH using the RUBYLIB environment variable
-SET RUBYLIB=%BOLT_DIR%\lib;%RUBYLIB%
+SET RUBYLIB=%BOLT_BASEDIR%\lib;%RUBYLIB%
 
 REM Translate all slashes to / style to avoid issue #11930
 SET RUBYLIB=%RUBYLIB:\=/%
 
-REM Now return to the caller.
-
 REM Set SSL variables to ensure trusted locations are used
-SET SSL_CERT_FILE=%BOLT_DIR%\ssl\cert.pem
-SET SSL_CERT_DIR=%BOLT_DIR%\ssl\certs
-SET OPENSSL_CONF=%BOLT_DIR%\ssl\openssl.cnf
+SET SSL_CERT_FILE=%BOLT_BASEDIR%\ssl\cert.pem
+SET SSL_CERT_DIR=%BOLT_BASEDIR%\ssl\certs
+SET OPENSSL_CONF=%BOLT_BASEDIR%\ssl\openssl.cnf
 
 ruby -S -- bolt %*


### PR DESCRIPTION
This commit fixes the paths set to the core environment variables for the ruby environment the bolt commandline expects.

Commit 917bbb1c40175c7863fb1fa7d76ca86da3da3f04 which implemented this was a copy paste of the Puppet bat approach, but did not account for the different path structure Puppet has compared to bolt.

Fixes: https://github.com/puppetlabs/bolt/issues/2650