### PR TITLE
(maint) Create bootsnap cache on install

### DIFF
--- a/configs/components/bolt.json
+++ b/configs/components/bolt.json
@@ -1,1 +1,1 @@
-{"url":"git://github.com/puppetlabs/bolt.git","ref":"refs/tags/3.9.0"}
+{"url":"git://github.com/jpogran/bolt.git","ref":"gogobootsnap"}

--- a/configs/components/bolt.rb
+++ b/configs/components/bolt.rb
@@ -22,6 +22,8 @@ component "bolt" do |pkg, settings, platform|
 
     pkg.add_source("file://resources/files/windows/bolt.bat", sum: "60ead805dc78855d4a1a13230c141daa")
     pkg.install_file "../bolt.bat", "#{settings[:link_bindir]}/bolt.bat"
+    # Bolt Data folder
+    pkg.directory File.join(settings[:bootsnap_datadir], 'bolt'), mode: '0755'
 
     # PowerShell Module
     pkg.directory "#{settings[:datadir]}/PowerShell/Modules/PuppetBolt"

--- a/configs/projects/puppet-bolt.rb
+++ b/configs/projects/puppet-bolt.rb
@@ -41,6 +41,7 @@ project "puppet-bolt" do |proj|
     proj.setting(:LicenseRTF, "wix/license/LICENSE.rtf")
     proj.setting(:install_root, File.join("C:", proj.base_dir, proj.company_id, proj.product_id))
     proj.setting(:link_bindir, File.join(proj.install_root, "bin"))
+    proj.setting(:bootsnap_datadir, File.join("C:", "CommonAppDataFolder", proj.company_id))
 
     module_directory = File.join(proj.datadir.sub(/^.*:\//, ''), 'PowerShell', 'Modules')
     proj.extra_file_to_sign File.join(module_directory, 'PuppetBolt', 'PuppetBolt.psm1')
@@ -59,6 +60,7 @@ project "puppet-bolt" do |proj|
 
   proj.directory proj.prefix
   proj.directory proj.link_bindir
+  proj.directory proj.bootsnap_datadir if platform.is_windows?
 
   if platform.is_fedora? && platform.os_version.to_i >= 28
     # Disable shebang mangling for certain paths inside Bolt.

--- a/resources/windows/wix/bootsnap.vbs
+++ b/resources/windows/wix/bootsnap.vbs
@@ -1,0 +1,154 @@
+On Error Resume Next
+
+' This VBScript file is imported into the Binary table
+
+' Example INSTALLDIR property. Its value is 'C:\Program Files\Puppet Labs\Bolt\'.
+' As this is deferred, use the CustomActionData property instead
+Dim InstallDir : InstallDir = Session.Property("CustomActionData")
+
+' https://docs.microsoft.com/en-us/windows/desktop/msi/session-message
+Const msiMessageTypeError   = &H01000000
+Const msiMessageTypeWarning = &H02000000
+Const msiMessageTypeInfo    = &H04000000
+
+' https://docs.microsoft.com/en-us/windows/desktop/msi/return-values-of-jscript-and-vbscript-custom-actions
+Const IDOK = 1
+Const IDABORT = 3
+
+Dim wshShell : Set wshShell = CreateObject("WScript.Shell")
+Dim fso : Set fso = CreateObject("Scripting.FileSystemObject")
+Dim comspec : comspec = wshShell.ExpandEnvironmentStrings("%comspec%")
+
+Sub Log (Message, IsError)
+  ' Logs through cscript
+  If IsObject(WScript) Then
+    If IsObject(WScript.StdErr) And IsError = True Then
+      WScript.StdErr.WriteLine(Message)
+    ElseIf IsObject(WScript.StdOut) Then
+      WScript.StdOut.WriteLine(Message)
+    End If
+  End If
+  ' Logs through MSI
+  If IsObject(Session) Then
+    ' https://docs.microsoft.com/en-us/windows/desktop/msi/installer-createrecord
+    Dim logRecord : Set logRecord = Installer.CreateRecord(1) ' 1 entry
+    logRecord.StringData(1) = Message ' Set Index 1
+    Dim kind : kind = msiMessageTypeInfo
+    If IsError = True Then kind = msiMessageTypeError
+    Session.Message kind, logRecord
+  End If
+End Sub
+
+' Executes command, sending its stdout / stderr to the WScript host
+Function ExecuteCommand(Command)
+  Dim output: output = ""
+  Log "Executing Command : " & Command, False
+
+  Dim tempFilePath : tempFilePath = wshShell.ExpandEnvironmentStrings("%TEMP%\" + fso.GetTempName())
+  Dim tempBatFile : tempBatFile = wshShell.ExpandEnvironmentStrings("%TEMP%\" + fso.GetTempName() + ".bat")
+  ' Open the temp .bat file for writing
+  ' Unfortunately due to the strange double quoting behaviour in wshShell.Run we create a temporary
+  ' Batch file with the command we want, and then call the batch file.  Note that we explicitly call
+  ' EXIT /B so that we avoid the case where someone malicious modifies the BAT file while being run.
+  ' Remember that cmd.exe reads and executes BAT files line-by-line. The EXIT statement tells cmd
+  ' to exit even if there's malicious code following.
+  Dim outFile : Set outFile = fso.OpenTextFile(tempBatFile, 2, true)
+  outFile.WriteLine(Command & " > """ & tempFilePath & """ 2>&1 && EXIT /B %ERRORLEVEL%")
+  outFile.Close()
+  Set outFile = Nothing
+  ' https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/d5fk67ky%28v%3dvs.84%29
+  ' intWindows Style - 0 - Hides the window and activates another window.
+  ' bWaitOnReturn - True - waits for program termination
+  Dim exitCode : exitCode = wshShell.Run(comspec & " /c CALL " & tempBatFile & " 2>&1", 0, True)
+  fso.DeleteFile(tempBatFile)
+  If fso.FileExists(tempFilePath) Then
+    Set outFile = fso.OpenTextFile(tempFilePath)
+    Log "--- Output", false
+    Do While Not outFile.AtEndOfStream
+    Log outFile.ReadLine(), false
+    Loop
+    outFile.Close()
+    Log "---", false
+    fso.DeleteFile(tempFilePath)
+  End If
+
+  If exitCode <> 0 Then
+    Log "Execution Failed With Code: " & exitCode, True
+    ExecuteCommand = False
+  else
+    ExecuteCommand = True
+  End If
+End Function
+
+Function GetRubyDirectory(RootDirectory)
+  GetRubyDirectory = ""
+  ' Find a ruby environment with the PDK gem
+  Dim RubyFolder : Set RubyFolder = fso.GetFolder(RootDirectory)
+  For Each RubyVerSubfolder in RubyFolder.SubFolders
+    Dim RubyFullVersion : RubyFullVersion = RubyVerSubfolder.Name
+    Dim arrRubyVersion : arrRubyVersion = Split(RubyFullVersion, ".")
+    Dim RubyMinorVersion : RubyMinorVersion = arrRubyVersion(0) + "." + arrRubyVersion(1) + ".0"
+    Dim GemFolderPath : GemFolderPath = RubyVerSubfolder.Path + "\lib\ruby\gems\" + RubyMinorVersion + "\gems"
+
+    if fso.FolderExists(GemFolderPath) Then
+      Dim FoundPDK : FoundPDK = false
+      For Each GemFolder in fso.GetFolder(GemFolderPath).SubFolders
+        FoundPDK = FoundPDK OR Left(GemFolder.Name,4) = "pdk-"
+      Next
+      If FoundPDK Then
+        GetRubyDirectory = RubyFullVersion
+      End If
+    End If
+  Next
+End Function
+
+' Mainline
+Function RunRubyCommand(command)
+  Log "InstallDir is " + InstallDir, false
+
+  ' Based on equivalent PowerShell script at;
+  ' https://github.com/puppetlabs/pdk-vanagon/blob/07a4ee7c29ba630ffbec6d87388688b6de90fbfd/resources/files/windows/PuppetDevelopmentKit/PuppetDevelopmentKit.psm1
+  Dim BOLT_BASEDIR
+  Dim RUBY_DIR
+  Dim SSL_CERT_FILE
+  Dim SSL_CERT_DIR
+
+  BOLT_BASEDIR = fso.GetFolder(InstallDir).ShortPath
+
+  Log "BOLT_BASEDIR is " + BOLT_BASEDIR, false
+  RUBY_DIR = BOLT_BASEDIR + "\lib\ruby\"
+  SSL_CERT_FILE = BOLT_BASEDIR + "\ssl\cert.pem"
+  SSL_CERT_DIR = BOLT_BASEDIR + "\ssl\certs"
+
+  Log "BOLT_BASEDIR is " + BOLT_BASEDIR, false
+  Log "RUBY_DIR is " + RUBY_DIR, false
+  Log "SSL_CERT_FILE is " + SSL_CERT_FILE, false
+  Log "SSL_CERT_DIR is " + SSL_CERT_DIR, false
+
+  Dim RubyPath : RubyPath = BOLT_BASEDIR + "\bin\ruby.exe"
+  Dim BundlePath : BundlePath = BOLT_BASEDIR + "\bin\bundle"
+  Dim ProcessEnv : Set ProcessEnv = wshShell.Environment( "PROCESS" )
+
+  Log "Creating process level environment variables...", false
+  ProcessEnv("BOLT_BASEDIR") = BOLT_BASEDIR
+  ProcessEnv("RUBY_DIR") = RUBY_DIR
+  ProcessEnv("SSL_CERT_FILE") = SSL_CERT_FILE
+  ProcessEnv("SSL_CERT_DIR") = SSL_CERT_DIR
+  ProcessEnv("PDK_DEBUG") = "True"
+  Dim NewEnvPath : NewEnvPath = BOLT_BASEDIR + "\bin;" + ProcessEnv("PATH")
+  ProcessEnv("PATH") = NewEnvPath
+
+  ' Note Returning values back to the MSI Engine only works with Binary type Custom Actions
+  ' if ExecuteCommand("""" & RubyPath & """ -S -- """ & ExtractScript & """") Then
+  if ExecuteCommand(command) Then
+    Log "Completed with success", false
+    RunRubyCommand = IDOK
+  Else
+    Log "Completed with error", true
+    RunRubyCommand = IDABORT
+  End If
+End Function
+
+Function RunBootsnap()
+  ExtractTarballs = RunRubyCommand("bundle exec bootsnap precompile --cache-dir /home/james/puppetlabs/etc/pdk --gemfile lib/")
+End Function

--- a/resources/windows/wix/bootsnap.vbs
+++ b/resources/windows/wix/bootsnap.vbs
@@ -75,7 +75,7 @@ Function ExecuteCommand(Command)
   If exitCode <> 0 Then
     Log "Execution Failed With Code: " & exitCode, True
     ExecuteCommand = False
-  else
+  Else
     ExecuteCommand = True
   End If
 End Function
@@ -90,7 +90,7 @@ Function GetRubyDirectory(RootDirectory)
     Dim RubyMinorVersion : RubyMinorVersion = arrRubyVersion(0) + "." + arrRubyVersion(1) + ".0"
     Dim GemFolderPath : GemFolderPath = RubyVerSubfolder.Path + "\lib\ruby\gems\" + RubyMinorVersion + "\gems"
 
-    if fso.FolderExists(GemFolderPath) Then
+    If fso.FolderExists(GemFolderPath) Then
       Dim FoundPDK : FoundPDK = false
       For Each GemFolder in fso.GetFolder(GemFolderPath).SubFolders
         FoundPDK = FoundPDK OR Left(GemFolder.Name,4) = "pdk-"
@@ -140,7 +140,7 @@ Function RunRubyCommand(command)
 
   ' Note Returning values back to the MSI Engine only works with Binary type Custom Actions
   ' if ExecuteCommand("""" & RubyPath & """ -S -- """ & ExtractScript & """") Then
-  if ExecuteCommand(command) Then
+  If ExecuteCommand(command) Then
     Log "Completed with success", false
     RunRubyCommand = IDOK
   Else
@@ -151,8 +151,11 @@ End Function
 
 Function RunBootsnap()
   Dim BOLT_BASEDIR
+  Dim BOLT_PROGRAMDATA
   Dim cmd
   BOLT_BASEDIR = fso.GetFolder(InstallDir).ShortPath
-  cmd = "bootsnap precompile '" + BOLT_BASEDIR + "' --cache-dir c:/ProgramData/Puppetlabs/bolt"
-  ExtractTarballs = RunRubyCommand(cmd)
+  BOLT_PROGRAMDATA = wshShell.ExpandEnvironmentStrings("%PROGRAMDATA%\PuppetLabs\bolt")
+
+  cmd = "bootsnap precompile '" + BOLT_BASEDIR + "' --cache-dir '" + BOLT_PROGRAMDATA
+  RunBootsnap = RunRubyCommand(cmd)
 End Function

--- a/resources/windows/wix/bootsnap.vbs
+++ b/resources/windows/wix/bootsnap.vbs
@@ -150,5 +150,9 @@ Function RunRubyCommand(command)
 End Function
 
 Function RunBootsnap()
-  ExtractTarballs = RunRubyCommand("bundle exec bootsnap precompile --cache-dir /home/james/puppetlabs/etc/pdk --gemfile lib/")
+  Dim BOLT_BASEDIR
+  Dim cmd
+  BOLT_BASEDIR = fso.GetFolder(InstallDir).ShortPath
+  cmd = "bootsnap precompile '" + BOLT_BASEDIR + "' --cache-dir c:/ProgramData/Puppetlabs/bolt"
+  ExtractTarballs = RunRubyCommand(cmd)
 End Function

--- a/resources/windows/wix/bootsnap.wxs
+++ b/resources/windows/wix/bootsnap.wxs
@@ -1,0 +1,37 @@
+<?xml version='1.0' encoding='windows-1252'?>
+<Wix xmlns='http://schemas.microsoft.com/wix/2006/wi' xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
+  <!-- Create a PuppetLabs\Bolt folder in the %PROGRAMDATA% folder.
+    This is largely copied from the puppet-agent vanagon -->
+  <Fragment>
+    <DirectoryRef Id='TARGETDIR'>
+      <Directory Id="CommonAppDataFolder" Name="CommonAppData">
+        <!-- Use the same dir name as puppet-agent so we don't have a
+        PuppetLabs and Puppet Labs directories -->
+        <Directory Id="PROGRAMDATADIR" Name="PuppetLabs">
+          <Directory Id="BoltAppData" Name="bolt"/>
+        </Directory>
+      </Directory>
+    </DirectoryRef>
+
+    <ComponentGroup Id="BoltDataComponentGroup" >
+      <Component
+        Id="PuppetLabsDataDir"
+        Guid="EA55AEDB-3A9E-454E-9389-828341BEB4FC"
+        Permanent="yes"
+        Directory="PROGRAMDATADIR">
+        <CreateFolder>
+          <PermissionEx Sddl="O:SYG:SYD:P(A;OICI;0x1200a9;;;WD)(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)" />
+        </CreateFolder>
+      </Component>
+      <Component
+        Id="BoltAppDir"
+        Guid="73AAE7BD-6597-4A19-AAED-92EDF2618DA9"
+        Permanent="yes"
+        Directory="BoltAppData" >
+        <CreateFolder>
+          <PermissionEx Sddl="O:SYG:SYD:P(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)" />
+        </CreateFolder>
+      </Component>
+    </ComponentGroup>
+  </Fragment>
+</Wix>

--- a/resources/windows/wix/componentgroup.wxs.erb
+++ b/resources/windows/wix/componentgroup.wxs.erb
@@ -9,6 +9,7 @@
 
       <!-- We can add all components by referencing this one thing -->
       <ComponentGroupRef Id="AppComponentGroup" />
+      <ComponentGroupRef Id="BoltDataComponentGroup" />
       <ComponentGroupRef Id="PowerShellModuleComponentGroup" />
 
       <!-- All of these Include refs are expected to be present -->

--- a/resources/windows/wix/customactions.wxs.erb
+++ b/resources/windows/wix/customactions.wxs.erb
@@ -35,6 +35,19 @@
       Return="check"
       Impersonate="no" />
 
+    <CustomAction
+      Id="SetPropertyForRunBootsnap"
+      Property="RunBootsnap"
+      Value="[INSTALLDIR]" />
+    <Binary Id='BootsnapScript' SourceFile='..\bootsnap.vbs' />
+    <CustomAction
+      Id="RunBootsnap"
+      BinaryKey="BootsnapScript"
+      VBScriptCall="RunBootsnap"
+      Execute="deferred"
+      Return="check"
+      Impersonate="no" />
+
     <!-- INSTALLDIR is not available for Deferred Custom Actions.  So we need to save it for later user -->
     <CustomAction
       Id="SetPropertyForRemoveTarballs"

--- a/resources/windows/wix/sequences.wxs.erb
+++ b/resources/windows/wix/sequences.wxs.erb
@@ -24,6 +24,9 @@
       <!-- Tarball Extractor on install -->
       <Custom Action="SetPropertyForExtractTarballs" Before="InstallInitialize">NOT REMOVE</Custom>
       <Custom Action='ExtractTarballs' After='InstallFiles'>NOT REMOVE</Custom>
+      <!-- Run Bootsnap on install -->
+      <Custom Action="SetPropertyForRunBootsnap" Before="InstallInitialize">NOT REMOVE</Custom>
+      <Custom Action='RunBootsnap' After='InstallFiles'>NOT REMOVE</Custom>
       <!-- Tarball Remover on uninstall -->
       <Custom Action="SetPropertyForRemoveTarballs" Before="InstallInitialize">REMOVE~="ALL" OR MaintenanceMode="Remove"</Custom>
       <Custom Action='RemoveTarballs' Before='RemoveFiles'>REMOVE~="ALL" OR MaintenanceMode="Remove"</Custom>


### PR DESCRIPTION
- [x] Change bolt bootsnap cache dir to `$env:ProgramData/Puppetlabs/bolt` in bolt project
- [x] Run bootsnap compile command on install, point cache to `$env:ProgramData/Puppetlabs/bolt`
- [x] Ensure permissions on `$env:ProgramData/Puppetlabs/bolt` allow user to update cache

Acceptance Criteria

- [x] Validate that cache is create in `$env:ProgramData/Puppetlabs/bolt/bootsnap`
- [x] Validate bolt starts without error
- [x] Validate cache is not created if the folder is not writeable
