### PR TITLE
(maint) Build el-6 packages on RedHat 6

### DIFF
--- a/configs/platforms/el-6-x86_64.rb
+++ b/configs/platforms/el-6-x86_64.rb
@@ -7,5 +7,5 @@ platform "el-6-x86_64" do |plat|
   plat.provision_with "rpm --import http://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs"
   plat.provision_with "yum install --assumeyes autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utilsi autogen git"
   plat.install_build_dependencies_with "yum install --assumeyes"
-  plat.vmpooler_template "centos-6-x86_64"
+  plat.vmpooler_template "redhat-6-x86_64"
 end


### PR DESCRIPTION
This updates the build process to build el-6 packages on RedHat 6.
Previously, el-6 packages were built on centos-6, but the upstream repo
for that platform was removed by centos. This same change can also be
found in
[puppet-runtime](https://github.com/puppetlabs/puppet-runtime/commit/3f69db4c9eeda808379155b8037c21d7a4fda18f#diff-477edc1e13621457ee11ef723b62d8cd43b8f4081add074859465a407c8cd842).