### PR TITLE
(maint) Update ref for pupperware to 'main'

### DIFF
--- a/docker/Gemfile
+++ b/docker/Gemfile
@@ -4,5 +4,5 @@ gem 'rspec'
 gem 'rspec_junit_formatter'
 gem 'pupperware',
   :git => 'https://github.com/puppetlabs/pupperware.git',
-  :ref => 'master',
+  :ref => 'main',
   :glob => 'gem/*.gemspec'


### PR DESCRIPTION
The default branch for the pupperware repo is now `main` instead of
`master`. This updates the Gemfile for the Docker image build to use the
`main` branch for the pupperware repo instead of `master`.