### PR TITLE
(VANAGON-85) Ensure packages can be built with older vanagons

### DIFF
--- a/configs/platforms/debian-10-amd64.rb
+++ b/configs/platforms/debian-10-amd64.rb
@@ -1,5 +1,18 @@
 platform "debian-10-amd64" do |plat|
-  plat.inherit_from_default
-  packages = %w(git)
-  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends #{packages.join(' ')}"
+  # If we're using a new enough Vanagon that has this method, use it
+  if defined?(plat.inherit_from_default)
+    plat.inherit_from_default
+    packages = %w(git)
+    plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends #{packages.join(' ')}"
+  # Otherwise, fall back to the old way
+  else
+    plat.servicedir "/lib/systemd/system"
+    plat.defaultdir "/etc/default"
+    plat.servicetype "systemd"
+    plat.codename "buster"
+    packages = %w[build-essential devscripts make quilt pkg-config debhelper rsync fakeroot libssl-dev ruby-full rubygems git]
+    plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends #{packages.join(' ')}"
+    plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends --force-yes "
+    plat.vmpooler_template "debian-10-x86_64"
+  end
 end

--- a/configs/platforms/debian-9-amd64.rb
+++ b/configs/platforms/debian-9-amd64.rb
@@ -1,5 +1,20 @@
 platform "debian-9-amd64" do |plat|
-  plat.inherit_from_default
-  packages = %w(git)
-  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends #{packages.join(' ')}"
+  # If we're using a new enough Vanagon that has this method, use it
+  if defined?(plat.inherit_from_default)
+    plat.inherit_from_default
+    packages = %w(git)
+    plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends #{packages.join(' ')}"
+  # Otherwise, fall back to the old way
+  else
+    plat.servicedir "/lib/systemd/system"
+    plat.defaultdir "/etc/default"
+    plat.servicetype "systemd"
+    plat.codename "stretch"
+
+    plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-#{plat.get_codename}.deb"
+
+    plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper rsync fakeroot libssl-dev ruby-full rubygems git"
+    plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends --force-yes "
+    plat.vmpooler_template "debian-9-x86_64"
+  end
 end

--- a/configs/platforms/el-6-x86_64.rb
+++ b/configs/platforms/el-6-x86_64.rb
@@ -1,5 +1,19 @@
 platform "el-6-x86_64" do |plat|
-  plat.inherit_from_default
-  packages = %w(git)
-  plat.provision_with "yum install --assumeyes #{packages.join(' ')}"
+  # If we're using a new enough Vanagon that has this method, use it
+  if defined?(plat.inherit_from_default)
+    plat.inherit_from_default
+    packages = %w(git)
+    plat.provision_with "yum install --assumeyes #{packages.join(' ')}"
+    # Otherwise, fall back to the old way
+  else
+    plat.servicedir "/etc/rc.d/init.d"
+    plat.defaultdir "/etc/sysconfig"
+    plat.servicetype "sysv"
+
+    plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/pl-build-tools-release-#{plat.get_os_name}-#{plat.get_os_version}.noarch.rpm"
+    plat.provision_with "rpm --import http://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs"
+    plat.provision_with "yum install --assumeyes autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utilsi autogen git"
+    plat.install_build_dependencies_with "yum install --assumeyes"
+    plat.vmpooler_template "redhat-6-x86_64"
+  end
 end

--- a/configs/platforms/el-7-x86_64.rb
+++ b/configs/platforms/el-7-x86_64.rb
@@ -1,5 +1,19 @@
 platform "el-7-x86_64" do |plat|
-  plat.inherit_from_default
-  packages = %w(git)
-  plat.provision_with("yum install -y #{packages.join(' ')}")
+  # If we're using a new enough Vanagon that has this method, use it
+  if defined?(plat.inherit_from_default)
+    plat.inherit_from_default
+    packages = %w(git)
+    plat.provision_with "yum install --assumeyes #{packages.join(' ')}"
+    # Otherwise, fall back to the old way
+  else
+    plat.servicedir "/usr/lib/systemd/system"
+    plat.defaultdir "/etc/sysconfig"
+    plat.servicetype "systemd"
+
+    plat.provision_with "rpm --import http://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs"
+    plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/pl-build-tools-release-#{plat.get_os_name}-#{plat.get_os_version}.noarch.rpm"
+    plat.provision_with "yum install --assumeyes autoconf automake rsync gcc createrepo make rpmdevtools rpm-libs yum-utils rpm-sign libtool autogen git"
+    plat.install_build_dependencies_with "yum install --assumeyes"
+    plat.vmpooler_template "centos-7-x86_64"
+  end
 end

--- a/configs/platforms/el-8-x86_64.rb
+++ b/configs/platforms/el-8-x86_64.rb
@@ -1,5 +1,18 @@
 platform "el-8-x86_64" do |plat|
-  plat.inherit_from_default
-  packages = %w(git)
-  plat.provision_with("yum install -y #{packages.join(' ')}")
+  # If we're using a new enough Vanagon that has this method, use it
+  if defined?(plat.inherit_from_default)
+    plat.inherit_from_default
+    packages = %w(git)
+    plat.provision_with "yum install --assumeyes #{packages.join(' ')}"
+    # Otherwise, fall back to the old way
+  else
+    plat.servicedir "/usr/lib/systemd/system"
+    plat.defaultdir "/etc/sysconfig"
+    plat.servicetype "systemd"
+
+    plat.provision_with "rpm --import http://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs"
+    plat.provision_with "yum install --assumeyes autoconf automake rsync gcc createrepo make rpmdevtools rpm-libs yum-utils rpm-sign libtool git"
+    plat.install_build_dependencies_with "yum install --assumeyes"
+    plat.vmpooler_template "redhat-8-x86_64"
+  end
 end

--- a/configs/platforms/fedora-30-x86_64.rb
+++ b/configs/platforms/fedora-30-x86_64.rb
@@ -1,5 +1,25 @@
 platform "fedora-30-x86_64" do |plat|
-  plat.inherit_from_default
-  packages = %w(git)
-  plat.provision_with("/usr/bin/dnf install -y --best --allowerasing #{packages.join(' ')}")
+  # If we're using a new enough Vanagon that has this method, use it
+  if defined?(plat.inherit_from_default)
+    plat.inherit_from_default
+    packages = %w(git)
+    plat.provision_with("/usr/bin/dnf install -y --best --allowerasing #{packages.join(' ')}")
+  # Otherwise, fall back to the old way
+  else
+    plat.servicedir "/usr/lib/systemd/system"
+    plat.defaultdir "/etc/sysconfig"
+    plat.servicetype "systemd"
+
+    plat.vmpooler_template "fedora-30-x86_64"
+    plat.dist "fc30"
+
+    packages = %w[
+    autoconf automake bzip2-devel gcc gcc-c++
+    make cmake pkgconfig readline-devel
+    rpm-libs rpmdevtools rsync swig zlib-devel git
+    ]
+    plat.provision_with("/usr/bin/dnf install -y --best --allowerasing #{packages.join(' ')}")
+
+    plat.install_build_dependencies_with "/usr/bin/dnf install -y --best --allowerasing"
+  end
 end

--- a/configs/platforms/fedora-31-x86_64.rb
+++ b/configs/platforms/fedora-31-x86_64.rb
@@ -1,5 +1,25 @@
 platform "fedora-31-x86_64" do |plat|
-  plat.inherit_from_default
-  packages = %w(git)
-  plat.provision_with "/usr/bin/dnf install -y --best --allowerasing  #{packages.join(' ')}"
+  # If we're using a new enough Vanagon that has this method, use it
+  if defined?(plat.inherit_from_default)
+    plat.inherit_from_default
+    packages = %w(git)
+    plat.provision_with("/usr/bin/dnf install -y --best --allowerasing #{packages.join(' ')}")
+    # Otherwise, fall back to the old way
+  else
+    plat.servicedir "/usr/lib/systemd/system"
+    plat.defaultdir "/etc/sysconfig"
+    plat.servicetype "systemd"
+
+    plat.vmpooler_template "fedora-31-x86_64"
+    plat.dist "fc31"
+
+    packages = %w[
+    autoconf automake bzip2-devel gcc gcc-c++
+    make cmake pkgconfig readline-devel
+    rpm-libs rpmdevtools rsync swig zlib-devel git
+    ]
+    plat.provision_with("/usr/bin/dnf install -y --best --allowerasing #{packages.join(' ')}")
+
+    plat.install_build_dependencies_with "/usr/bin/dnf install -y --best --allowerasing"
+  end
 end

--- a/configs/platforms/fedora-32-x86_64.rb
+++ b/configs/platforms/fedora-32-x86_64.rb
@@ -1,5 +1,25 @@
 platform "fedora-32-x86_64" do |plat|
-  plat.inherit_from_default
-  packages = %w(git)
-  plat.provision_with "/usr/bin/dnf install -y --best --allowerasing #{packages.join(' ')}"
+  # If we're using a new enough Vanagon that has this method, use it
+  if defined?(plat.inherit_from_default)
+    plat.inherit_from_default
+    packages = %w(git)
+    plat.provision_with("/usr/bin/dnf install -y --best --allowerasing #{packages.join(' ')}")
+    # Otherwise, fall back to the old way
+  else
+    plat.servicedir "/usr/lib/systemd/system"
+    plat.defaultdir "/etc/sysconfig"
+    plat.servicetype "systemd"
+
+    plat.vmpooler_template "fedora-32-x86_64"
+    plat.dist "fc32"
+
+    packages = %w[
+    autoconf automake bzip2-devel gcc gcc-c++
+    make cmake pkgconfig readline-devel
+    rpmdevtools rsync swig zlib-devel git
+    ]
+    plat.provision_with("/usr/bin/dnf install -y --best --allowerasing #{packages.join(' ')}")
+
+    plat.install_build_dependencies_with "/usr/bin/dnf install -y --best --allowerasing"
+  end
 end

--- a/configs/platforms/osx-10.14-x86_64.rb
+++ b/configs/platforms/osx-10.14-x86_64.rb
@@ -1,3 +1,29 @@
 platform "osx-10.14-x86_64" do |plat|
-  plat.inherit_from_default
+  # If we're using a new enough Vanagon that has this method, use it
+  if defined?(plat.inherit_from_default)
+    plat.inherit_from_default
+  # Otherwise, fall back to the old way
+  else
+    plat.servicetype 'launchd'
+    plat.servicedir '/Library/LaunchDaemons'
+    plat.codename "mojave"
+
+    plat.provision_with 'export HOMEBREW_NO_EMOJI=true'
+    plat.provision_with 'export HOMEBREW_VERBOSE=true'
+
+    plat.provision_with 'sudo dscl . -create /Users/test'
+    plat.provision_with 'sudo dscl . -create /Users/test UserShell /bin/bash'
+    plat.provision_with 'sudo dscl . -create /Users/test UniqueID 1001'
+    plat.provision_with 'sudo dscl . -create /Users/test PrimaryGroupID 1000'
+    plat.provision_with 'sudo dscl . -create /Users/test NFSHomeDirectory /Users/test'
+    plat.provision_with 'sudo dscl . -passwd /Users/test password'
+    plat.provision_with 'sudo dscl . -merge /Groups/admin GroupMembership test'
+    plat.provision_with 'echo "test ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/username'
+    plat.provision_with 'mkdir -p /etc/homebrew'
+    plat.provision_with 'cd /etc/homebrew'
+    plat.provision_with 'su test -c \'echo | /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"\''
+    plat.provision_with 'sudo chown -R test:admin /Users/test/Library/'
+    plat.vmpooler_template "osx-1014-x86_64"
+    plat.output_dir File.join("apple", "10.14", "PC1", "x86_64")
+  end
 end

--- a/configs/platforms/osx-10.15-x86_64.rb
+++ b/configs/platforms/osx-10.15-x86_64.rb
@@ -1,3 +1,27 @@
 platform "osx-10.15-x86_64" do |plat|
-  plat.inherit_from_default
+  if defined?(plat.inherit_from_default)
+    plat.inherit_from_default
+  else
+    plat.servicetype 'launchd'
+    plat.servicedir '/Library/LaunchDaemons'
+    plat.codename "catalina"
+
+    plat.provision_with 'export HOMEBREW_NO_EMOJI=true'
+    plat.provision_with 'export HOMEBREW_VERBOSE=true'
+
+    plat.provision_with 'sudo dscl . -create /Users/test'
+    plat.provision_with 'sudo dscl . -create /Users/test UserShell /bin/bash'
+    plat.provision_with 'sudo dscl . -create /Users/test UniqueID 1001'
+    plat.provision_with 'sudo dscl . -create /Users/test PrimaryGroupID 1000'
+    plat.provision_with 'sudo dscl . -create /Users/test NFSHomeDirectory /Users/test'
+    plat.provision_with 'sudo dscl . -passwd /Users/test password'
+    plat.provision_with 'sudo dscl . -merge /Groups/admin GroupMembership test'
+    plat.provision_with 'echo "test ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/username'
+    plat.provision_with 'mkdir -p /etc/homebrew'
+    plat.provision_with 'cd /etc/homebrew'
+    plat.provision_with 'su test -c \'echo | /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"\''
+    plat.provision_with 'sudo chown -R test:admin /Users/test/Library/'
+    plat.vmpooler_template "osx-1015-x86_64"
+    plat.output_dir File.join("apple", "10.15", "PC1", "x86_64")
+  end
 end

--- a/configs/platforms/sles-12-x86_64.rb
+++ b/configs/platforms/sles-12-x86_64.rb
@@ -1,5 +1,18 @@
 platform "sles-12-x86_64" do |plat|
-  plat.inherit_from_default
-  packages = %w(git)
-  plat.provision_with("zypper -n install -y #{packages.join(' ')}")
+  # If we're using a new enough Vanagon that has this method, use it
+  if defined?(plat.inherit_from_default)
+    plat.inherit_from_default
+    packages = %w(git)
+    plat.provision_with("zypper -n install -y #{packages.join(' ')}")
+  # Otherwise, fall back to the old way
+  else
+    plat.servicedir "/usr/lib/systemd/system"
+    plat.defaultdir "/etc/sysconfig"
+    plat.servicetype "systemd"
+
+    plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/pl-build-tools-release-#{plat.get_os_name}-#{plat.get_os_version}.noarch.rpm"
+    plat.provision_with "zypper -n --no-gpg-checks install -y aaa_base autoconf automake rsync gcc make rpm-build git"
+    plat.install_build_dependencies_with "zypper -n --no-gpg-checks install -y"
+    plat.vmpooler_template "sles-12-x86_64"
+  end
 end

--- a/configs/platforms/ubuntu-16.04-amd64.rb
+++ b/configs/platforms/ubuntu-16.04-amd64.rb
@@ -1,5 +1,19 @@
 platform "ubuntu-16.04-amd64" do |plat|
-  plat.inherit_from_default
-  packages = %w(git)
-  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends #{packages.join(' ')}"
+  # If we're using a new enough Vanagon that has this method, use it
+  if defined?(plat.inherit_from_default)
+    plat.inherit_from_default
+    packages = %w(git)
+    plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends #{packages.join(' ')}"
+  # Otherwise, fall back to the old way
+  else
+    plat.servicedir "/lib/systemd/system"
+    plat.defaultdir "/etc/default"
+    plat.servicetype "systemd"
+    plat.codename "xenial"
+
+    plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-#{plat.get_codename}.deb"
+    plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper rsync fakeroot git"
+    plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends --force-yes "
+    plat.vmpooler_template "ubuntu-1604-x86_64"
+  end
 end

--- a/configs/platforms/ubuntu-16.04-i386.rb
+++ b/configs/platforms/ubuntu-16.04-i386.rb
@@ -1,5 +1,19 @@
 platform "ubuntu-16.04-i386" do |plat|
-  plat.inherit_from_default
-  packages = %w(git)
-  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends #{packages.join(' ')}"
+  # If we're using a new enough Vanagon that has this method, use it
+  if defined?(plat.inherit_from_default)
+    plat.inherit_from_default
+    packages = %w(git)
+    plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends #{packages.join(' ')}"
+  # Otherwise, fall back to the old way
+  else
+    plat.servicedir "/lib/systemd/system"
+    plat.defaultdir "/etc/default"
+    plat.servicetype "systemd"
+    plat.codename "xenial"
+
+    plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-#{plat.get_codename}.deb"
+    plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper rsync fakeroot git"
+    plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends --force-yes "
+    plat.vmpooler_template "ubuntu-1604-i386"
+  end
 end

--- a/configs/platforms/ubuntu-18.04-amd64.rb
+++ b/configs/platforms/ubuntu-18.04-amd64.rb
@@ -1,5 +1,20 @@
 platform "ubuntu-18.04-amd64" do |plat|
-  plat.inherit_from_default
-  packages = %w(git)
-  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends #{packages.join(' ')}"
+  # If we're using a new enough Vanagon that has this method, use it
+  if defined?(plat.inherit_from_default)
+    plat.inherit_from_default
+    packages = %w(git)
+    plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends #{packages.join(' ')}"
+  # Otherwise, fall back to the old way
+  else
+    plat.servicedir "/lib/systemd/system"
+    plat.defaultdir "/etc/default"
+    plat.servicetype "systemd"
+    plat.codename "bionic"
+
+    plat.provision_with "curl https://enterprise.delivery.puppetlabs.net/pluto.pub.gpg | apt-key add - "
+    plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-#{plat.get_codename}.deb"
+    plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper rsync fakeroot git"
+    plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
+    plat.vmpooler_template "ubuntu-1804-x86_64"
+  end
 end

--- a/configs/platforms/ubuntu-20.04-amd64.rb
+++ b/configs/platforms/ubuntu-20.04-amd64.rb
@@ -1,5 +1,20 @@
 platform "ubuntu-20.04-amd64" do |plat|
-  plat.inherit_from_default
-  packages = %w(git)
-  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends #{packages.join(' ')}"
+  # If we're using a new enough Vanagon that has this method, use it
+  if defined?(plat.inherit_from_default)
+    plat.inherit_from_default
+    packages = %w(git)
+    plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends #{packages.join(' ')}"
+    # Otherwise, fall back to the old way
+  else
+    plat.servicedir "/lib/systemd/system"
+    plat.defaultdir "/etc/default"
+    plat.servicetype "systemd"
+    plat.codename "focal"
+
+    plat.provision_with "curl https://enterprise.delivery.puppetlabs.net/pluto.pub.gpg | apt-key add - "
+    plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-#{plat.get_codename}.deb"
+    plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper rsync fakeroot git"
+    plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
+    plat.vmpooler_template "ubuntu-2004-x86_64"
+  end
 end


### PR DESCRIPTION
This amends #160 to only use the new `inherit_from_default` [vanagon
method](https://github.com/puppetlabs/vanagon/commit/6e797918782e749f2e68d67ca73e603f95f6ae3a)
if the version of Vanagon is new enough to have the method defined.
Because our CI sometimes defines `VANAGON_LOCATION` which overrides the
version of Vanagon defined in the Gemfile, this repo must continue to
support older versions of Vanagon.