### PR TITLE
(maint) remove obsolete 'gpg_name' configuration

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -2,7 +2,6 @@
 project: 'puppet-bolt'
 gem_name: 'bolt'
 build_gem: TRUE
-gpg_name: 'info@puppetlabs.com'
 sign_tar: FALSE
 vanagon_project: TRUE
 repo_name: 'puppet-enterprise-tools'


### PR DESCRIPTION
The 'gpg_name' configuration setting has been long-deprecated and throws a noisy warning. Removing the noise.