### PR TITLE
(GH-2855) Build bolt for macOS 11

### DIFF
--- a/configs/platforms/osx-11-x86_64.rb
+++ b/configs/platforms/osx-11-x86_64.rb
@@ -1,0 +1,3 @@
+platform "osx-11-x86_64" do |plat|
+  plat.inherit_from_default
+end


### PR DESCRIPTION
This adds macoS 11 as a platform so Bolt packages can be built for it.