### PR TITLE
(GH-2903) Build bolt for Fedora 34

### DIFF
--- a/configs/platforms/fedora-34-x86_64.rb
+++ b/configs/platforms/fedora-34-x86_64.rb
@@ -1,0 +1,5 @@
+platform "fedora-34-x86_64" do |plat|
+  plat.inherit_from_default
+  packages = %w(git)
+  plat.provision_with "/usr/bin/dnf install -y --best --allowerasing #{packages.join(' ')}"
+end


### PR DESCRIPTION
This adds Fedora 34 as a supported platform for Bolt.