### PR TITLE
(hack) Add Bolt builtin guides to PowerShell module

### DIFF
--- a/resources/windows/wix/powershell.wxs.erb
+++ b/resources/windows/wix/powershell.wxs.erb
@@ -24,12 +24,32 @@
       </Component>
 
       <Component
+        Id="about_bolt_debugging.help.txt"
+        Directory="PowerShellBoltModuleHelpDir"
+        Guid="d85b931b-98f4-4c66-a293-d77694f3ef21">
+        <File
+          Id="about_bolt_debugging.help.txt"
+          Source="$(var.AppSourcePath)\share\PowerShell\Modules\PuppetBolt\en-US\about_bolt_debugging.help.txt"
+          KeyPath="yes" />
+      </Component>
+
+      <Component
         Id="about_bolt_inventory.help.txt"
         Directory="PowerShellBoltModuleHelpDir"
         Guid="90b31dd1-28ef-4276-b672-8e87d432f70f">
         <File
           Id="about_bolt_inventory.help.txt"
           Source="$(var.AppSourcePath)\share\PowerShell\Modules\PuppetBolt\en-US\about_bolt_inventory.help.txt"
+          KeyPath="yes" />
+      </Component>
+
+      <Component
+        Id="about_bolt_links.help.txt"
+        Directory="PowerShellBoltModuleHelpDir"
+        Guid="b1e2ba32-9ca7-4c43-96c3-969c9660118b">
+        <File
+          Id="about_bolt_links.help.txt"
+          Source="$(var.AppSourcePath)\share\PowerShell\Modules\PuppetBolt\en-US\about_bolt_links.help.txt"
           KeyPath="yes" />
       </Component>
 
@@ -70,6 +90,26 @@
         <File
           Id="about_bolt_project.help.txt"
           Source="$(var.AppSourcePath)\share\PowerShell\Modules\PuppetBolt\en-US\about_bolt_project.help.txt"
+          KeyPath="yes" />
+      </Component>
+
+      <Component
+        Id="about_bolt_targets.help.txt"
+        Directory="PowerShellBoltModuleHelpDir"
+        Guid="d8ece074-473c-463d-afec-d3756b121a7a"
+        <File
+          Id="about_bolt_targets.help.txt"
+          Source="$(var.AppSourcePath)\share\PowerShell\Modules\PuppetBolt\en-US\about_bolt_targets.help.txt"
+          KeyPath="yes" />
+      </Component>
+
+      <Component
+        Id="about_bolt_transports.help.txt"
+        Directory="PowerShellBoltModuleHelpDir"
+        Guid="d03e7ebd-14f7-4c5d-99dc-e04ac057e332">
+        <File
+          Id="about_bolt_transports.help.txt"
+          Source="$(var.AppSourcePath)\share\PowerShell\Modules\PuppetBolt\en-US\about_bolt_transports.help.txt"
           KeyPath="yes" />
       </Component>
     </ComponentGroup>


### PR DESCRIPTION
This adds all of the Bolt builtin guides to the Bolt PowerShell module
so they can be used for `Get-Help bolt-#{topic}`.