### PR TITLE
(maint) Remove unsupported platforms

### DIFF
--- a/configs/platforms/fedora-30-x86_64.rb
+++ b/configs/platforms/fedora-30-x86_64.rb
@@ -1,5 +1,0 @@
-platform "fedora-30-x86_64" do |plat|
-  plat.inherit_from_default
-  packages = %w(git)
-  plat.provision_with("/usr/bin/dnf install -y --best --allowerasing #{packages.join(' ')}")
-end

--- a/configs/platforms/fedora-31-x86_64.rb
+++ b/configs/platforms/fedora-31-x86_64.rb
@@ -1,5 +1,0 @@
-platform "fedora-31-x86_64" do |plat|
-  plat.inherit_from_default
-  packages = %w(git)
-  plat.provision_with "/usr/bin/dnf install -y --best --allowerasing  #{packages.join(' ')}"
-end

--- a/configs/platforms/osx-10.14-x86_64.rb
+++ b/configs/platforms/osx-10.14-x86_64.rb
@@ -1,3 +1,0 @@
-platform "osx-10.14-x86_64" do |plat|
-  plat.inherit_from_default
-end


### PR DESCRIPTION
The release engineering team is removing vanagon support for Fedora 30,
Fedora 31, and OSX 10.14, in addition to removing support for the Puppet
Agent. This means that Bolt can no longer build packages for these
platforms, so is removing them.