### PR TITLE
(GH-2922) Save unset environment variables

### DIFF
--- a/resources/files/posix/bolt_env_wrapper
+++ b/resources/files/posix/bolt_env_wrapper
@@ -1,4 +1,22 @@
 #!/bin/sh
 
 # avoid influences from already pre-configured other ruby environments
-env -u GEM_HOME -u GEM_PATH -u DLN_LIBRARY_PATH -u RUBYLIB -u RUBYLIB_PREFIX -u RUBYOPT -u RUBYPATH -u RUBYSHELL -u LD_LIBRARY_PATH -u LD_PRELOAD SHELL=/bin/sh /opt/puppetlabs/bolt/bin/bolt "$@"
+env \
+  -u GEM_HOME \
+  -u GEM_PATH \
+  -u DLN_LIBRARY_PATH \
+  -u RUBYLIB \
+  -u RUBYLIB_PREFIX \
+  -u RUBYOPT \
+  -u RUBYPATH \
+  -u RUBYSHELL \
+  -u LD_LIBRARY_PATH \
+  -u LD_PRELOAD \
+  BOLT_ORIG_GEM_PATH=$GEM_PATH \
+  BOLT_ORIG_GEM_HOME=$GEM_HOME \
+  BOLT_ORIG_RUBYLIB=$RUBYLIB \
+  BOLT_ORIG_RUBYLIB_PREFIX=$RUBYLIB_PREFIX \
+  BOLT_ORIG_RUBYOPT=$RUBYOPT \
+  BOLT_ORIG_RUBYPATH=$RUBYPATH \
+  BOLT_ORIG_RUBYSHELL=$RUBYSHELL \
+  /opt/puppetlabs/bolt/bin/bolt "$@"


### PR DESCRIPTION
The `bolt_env_wrapper` script unsets several environment variables to
make Bolt execution predictable. Unsetting these variables also means
they are unset when Bolt runs Ruby tasks and scripts over the local
transport, which is incidental to Bolt being written in Ruby. The env
wrapper now saves Ruby-related environment variables to new
`BOLT_ORIG_<env_var>` variables, which allows Bolt to restore the
original values when running over the local transport with
`bundled-ruby` set to false.