### PR TITLE
Fix puppet-bolt Dockerfile linting.

### DIFF
--- a/docker/puppet-bolt/Dockerfile
+++ b/docker/puppet-bolt/Dockerfile
@@ -23,7 +23,7 @@ LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
 
 RUN apt-get update && \
     apt-get install --no-install-recommends -y wget ca-certificates lsb-release && \
-    wget http://apt.puppetlabs.com/puppet-tools-release-"$UBUNTU_CODENAME".deb && \
+    wget -q http://apt.puppetlabs.com/puppet-tools-release-"$UBUNTU_CODENAME".deb && \
     dpkg -i puppet-tools-release-"$UBUNTU_CODENAME".deb && \
     rm puppet-tools-release-"$UBUNTU_CODENAME".deb && \
     apt-get update && \


### PR DESCRIPTION
puppet-bolt is not pushed to the Docker Hub since bolt 3.18.0.
Upon inspection the Dockerfile couldn't be linted anymore, with following error:

`Dockerfile:24 DL3047 info: Avoid use of wget without progress bar. Use `wget --progress=dot:giga <url>`.Or consider using `-q` or `-nv` (shorthands for `--quiet` or `--no-verbose`).
Makefile:47: recipe for target 'lint' failed`

This (small) fix; fixes the Dockerfile linting for puppet-bolt.