### PR TITLE
(maint) Update bolt url.

### DIFF
--- a/configs/components/bolt.json
+++ b/configs/components/bolt.json
@@ -1,1 +1,1 @@
-{"url":"git://github.com/puppetlabs/bolt.git","ref":"0a81c0570af826453004853506dc9cb068860b93"}
+{"url":"git@github.com:puppetlabs/bolt.git","ref":"0a81c0570af826453004853506dc9cb068860b93"}


### PR DESCRIPTION
Update bolt url to comply with new security update that went into effect today (January 11, 2022).
https://github.blog/2021-09-01-improving-git-protocol-security-github/