### PR TITLE
(maint) Bump minimum version for packaging gem to 0.105

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,6 @@ end
 gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 0.7")
 gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 0.1")
 gem 'vanagon', *location_for(ENV['VANAGON_LOCATION'] || '~> 0.21')
-gem 'packaging', *location_for(ENV['PACKAGING_LOCATION'] || '~> 0.99.42')
+gem 'packaging', *location_for(ENV['PACKAGING_LOCATION'] || '~> 0.105')
 gem 'json'
 gem 'rake'


### PR DESCRIPTION
This bumps the minimum version for the `packaging` gem to 0.105.0, as
Bolt packages are now available for el-9 and this is the earliest
version of the packaging gem that can build packages for that platform.

---

Support for el-9 added to the packaging gem [here](https://github.com/puppetlabs/packaging/commit/225fef5456f15b797ba839c2be4685d658d4f5b4)