### PR TITLE
(BOLT-1580) Gem pruning path correction

### DIFF
--- a/configs/components/gem-prune.rb
+++ b/configs/components/gem-prune.rb
@@ -4,6 +4,6 @@ component 'gem-prune' do |pkg, settings, platform|
   pkg.add_source('file://resources/rubygems-prune')
 
   pkg.build do
-    "GEM_PATH=\"#{settings[:host_gem]}\" RUBYOPT=\"-Irubygems-prune\" #{settings[:host_gem]} prune"
+    "GEM_PATH=\"#{settings[:gem_home]}\" RUBYOPT=\"-Irubygems-prune\" #{settings[:host_gem]} prune"
   end
 end


### PR DESCRIPTION
There was an error in the GEM_PATH set on https://github.com/puppetlabs/bolt-vanagon/pull/179 - corrected to point to the directory containing the project's gems rather than the gem binary.