### PR TITLE
Revert "(maint) Build Bolt for macOS 12, remove macOS 10.15"

### DIFF
--- a/configs/platforms/osx-10.15-x86_64.rb
+++ b/configs/platforms/osx-10.15-x86_64.rb
@@ -1,0 +1,3 @@
+platform "osx-10.15-x86_64" do |plat|
+  plat.inherit_from_default
+end

--- a/configs/platforms/osx-12-x86_64.rb
+++ b/configs/platforms/osx-12-x86_64.rb
@@ -1,3 +1,0 @@
-platform "osx-12-x86_64" do |plat|
-  plat.inherit_from_default
-end


### PR DESCRIPTION
Reverts puppetlabs/bolt-vanagon#186 due to https://tickets.puppetlabs.com/browse/BOLT-1586