### PR TITLE
(maint) Remove EOL platforms

### DIFF
--- a/configs/platforms/fedora-32-x86_64.rb
+++ b/configs/platforms/fedora-32-x86_64.rb
@@ -1,5 +1,0 @@
-platform "fedora-32-x86_64" do |plat|
-  plat.inherit_from_default
-  packages = %w(git)
-  plat.provision_with "/usr/bin/dnf install -y --best --allowerasing #{packages.join(' ')}"
-end

--- a/configs/platforms/ubuntu-16.04-amd64.rb
+++ b/configs/platforms/ubuntu-16.04-amd64.rb
@@ -1,5 +1,0 @@
-platform "ubuntu-16.04-amd64" do |plat|
-  plat.inherit_from_default
-  packages = %w(git)
-  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends #{packages.join(' ')}"
-end

--- a/configs/platforms/ubuntu-16.04-i386.rb
+++ b/configs/platforms/ubuntu-16.04-i386.rb
@@ -1,5 +1,0 @@
-platform "ubuntu-16.04-i386" do |plat|
-  plat.inherit_from_default
-  packages = %w(git)
-  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends #{packages.join(' ')}"
-end


### PR DESCRIPTION
This removes Fedora 32 and Ubuntu 16.04 as supported platforms.