### PR TITLE
(PE-36810) Stop using dynamic tmp directory for batch script

### DIFF
--- a/resources/windows/wix/tarball.vbs
+++ b/resources/windows/wix/tarball.vbs
@@ -44,8 +44,8 @@ Function ExecuteCommand(Command)
   Dim output: output = ""
   Log "Executing Command : " & Command, False
 
-  Dim tempFilePath : tempFilePath = wshShell.ExpandEnvironmentStrings("%TEMP%\" + fso.GetTempName())
-  Dim tempBatFile : tempBatFile = wshShell.ExpandEnvironmentStrings("%TEMP%\" + fso.GetTempName() + ".bat")
+  Dim tempFilePath : tempFilePath = fso.GetTempName()
+  Dim tempBatFile : tempBatFile = fso.GetTempName() + ".bat"
   ' Open the temp .bat file for writing
   ' Unfortunately due to the strange double quoting behaviour in wshShell.Run we create a temporary
   ' Batch file with the command we want, and then call the batch file.  Note that we explicitly call

--- a/resources/windows/wix/tarball.vbs
+++ b/resources/windows/wix/tarball.vbs
@@ -17,7 +17,9 @@ Const IDABORT = 3
 
 Dim wshShell : Set wshShell = CreateObject("WScript.Shell")
 Dim fso : Set fso = CreateObject("Scripting.FileSystemObject")
-Dim comspec : comspec = wshShell.ExpandEnvironmentStrings("%comspec%")
+' https://learn.microsoft.com/en-us/office/vba/language/reference/user-interface-help/getspecialfolder-method
+Dim systemPath : systemPath = fso.getSpecialFolder(1)
+Dim comspec : comspec = systemPath & "\cmd.exe"
 
 Sub Log (Message, IsError)
   ' Logs through cscript

--- a/resources/windows/wix/tarball.vbs
+++ b/resources/windows/wix/tarball.vbs
@@ -46,8 +46,10 @@ Function ExecuteCommand(Command)
   Dim output: output = ""
   Log "Executing Command : " & Command, False
 
-  Dim tempFilePath : tempFilePath = fso.GetTempName()
-  Dim tempBatFile : tempBatFile = fso.GetTempName() + ".bat"
+  Dim winPath : winPath = fso.getSpecialFolder(0)
+  Dim tempFilePath : tempFilePath = winPath & "\Installer\" & fso.GetTempName()
+  Dim tempBatFile : tempBatFile =  winPath & "\Installer\"  & fso.GetTempName() + ".bat"
+
   ' Open the temp .bat file for writing
   ' Unfortunately due to the strange double quoting behaviour in wshShell.Run we create a temporary
   ' Batch file with the command we want, and then call the batch file.  Note that we explicitly call


### PR DESCRIPTION
This commit removes the intermediate script constructed for installation from being written to the %TEMP% directory. Intead it is written to the same directory the script is being run from. This ensures users must be able to write to the directory this script is being run from (for example C:\windows\system32 instead of %TEMP%).