### PR TITLE
(maint) add debian 12 amd64 platform

### DIFF
--- a/configs/platforms/debian-12-amd64.rb
+++ b/configs/platforms/debian-12-amd64.rb
@@ -1,0 +1,5 @@
+platform "debian-12-amd64" do |plat|
+  plat.inherit_from_default
+  packages = %w(git)
+  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends #{packages.join(' ')}"
+end


### PR DESCRIPTION
[Successful Jenkins Vanagon Build](https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging-ship-repos_generic-builder/1506/)

Pipeline failure apparently is a non-issue. https://github.com/puppetlabs/bolt/issues/3280