### PR TITLE
(bugfix) git modules require git on linux

### DIFF
--- a/configs/components/bolt.rb
+++ b/configs/components/bolt.rb
@@ -40,6 +40,8 @@ component "bolt" do |pkg, settings, platform|
       pkg.install_file "resources/bolt_bash_completion.sh", "/etc/bash_completion.d/bolt.sh", mode: "0644"
     end
 
+    pkg.requires 'git' if platform.is_linux?
+
     if platform.is_macos?
       pkg.add_source 'file://resources/files/paths.d/50-bolt', sum: '4abf75aebbbfbbefc4fe0173c57ed0b2'
       pkg.install_file('../50-bolt', '/etc/paths.d/50-bolt')


### PR DESCRIPTION
Fix for https://github.com/puppetlabs/bolt/issues/3306

It's common to using modules sourced from git, for example internal modules sourced from a private git repo).
This should generally work "out of the box".