### PR TITLE
(maint) Ensure legacy providers are loaded for bolt on windows

### DIFF
--- a/resources/files/windows/bolt.bat
+++ b/resources/files/windows/bolt.bat
@@ -17,5 +17,8 @@ REM Set SSL variables to ensure trusted locations are used
 SET SSL_CERT_FILE=%BOLT_BASEDIR%\ssl\cert.pem
 SET SSL_CERT_DIR=%BOLT_BASEDIR%\ssl\certs
 SET OPENSSL_CONF=%BOLT_BASEDIR%\ssl\openssl.cnf
+SET OPENSSL_CONF_INCLUDE=%BOLT_BASEDIR%\ssl
+SET OPENSSL_MODULES=%BOLT_BASEDIR%\lib\ossl-modules
+SET OPENSSL_ENGINES=%BOLT_BASEDIR%\lib\engines-3
 
 ruby -S -- bolt %*


### PR DESCRIPTION
This commit follows the precedent set in the agent in the follwoing commit: https://github.com/puppetlabs/puppet-agent/commit/f46d20258e6c016ca2808243594c83968f5b4d0b While we are not building bolt for fips at this time, setting these envirinment variables ensures our vendored openssl is as isolated as possible from anything that may be on a target install. See the relevant information from the linked commit message:

By default, openssl sets `OPENSSL_CONF_INCLUDE` to a directory relative to the --openssldir configuration option set at compilation time. But on Windows that's under C:\ProgramFiles64Folder. To ensure, we only load configuration from the user-specified install directory, set the `OPENSSL_CONF_INCLUDE` directory in environment.bat, like we do for other OpenSSL paths. The puppet.bat, etc batch wrapper scripts already call environment.bat to setup the environment.

Similarly, set `OPENSSL_MODULES` so that we load provider dlls from the correct location. And although we don't make use of engines, do the same for `OPENSSL_ENGINES`.

See https://www.openssl.org/docs/man3.0/man5/config.html