### PR TITLE
Remove ubuntu 24 platform

### DIFF
--- a/configs/platforms/ubuntu-24.04-amd64.rb
+++ b/configs/platforms/ubuntu-24.04-amd64.rb
@@ -1,3 +1,0 @@
-platform "ubuntu-24.04-amd64" do |plat|
-  plat.inherit_from_default
-end


### PR DESCRIPTION
Currently Bolt is having issues on ubuntu24 where puppet is not being installed under /opt/puppetlabs/puppet causing Bolt apply to not work, so we have decided to temporarily remove ubuntu24 until this issue is solved