### PR TITLE
(BOLT-36) Addressing ubuntu 2004 failing tests

### DIFF
--- a/configs/platforms/ubuntu-20.04-amd64.rb
+++ b/configs/platforms/ubuntu-20.04-amd64.rb
@@ -2,4 +2,5 @@ platform "ubuntu-20.04-amd64" do |plat|
   plat.inherit_from_default
   packages = %w(git)
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends #{packages.join(' ')}"
+  plat.provision_with "curl -fsSL https://github.com/rbenv/rbenv-installer/raw/HEAD/bin/rbenv-installer | bash; apt install rbenv -y; rbenv install 3.1.6; rbenv global 3.1.6; source ~/.bashrc"
 end


### PR DESCRIPTION
Following a set of release-blocking failures in Jenkins testings, we were forced to disable acceptance testing for the ubuntu2004 platform. This commit aims to address the failing tests by installing the neccesary ruby 3+ package for ubuntu 2004 through a PPA.